### PR TITLE
Fix packaging issues in Obfuscapk and vendor Yapsy locally

### DIFF
--- a/src/obfuscapk/obfuscators/advanced_reflection/__init__.py
+++ b/src/obfuscapk/obfuscators/advanced_reflection/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .advanced_reflection import AdvancedReflection
+from obfuscapk.obfuscators.advanced_reflection.advanced_reflection import AdvancedReflection

--- a/src/obfuscapk/obfuscators/arithmetic_branch/__init__.py
+++ b/src/obfuscapk/obfuscators/arithmetic_branch/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .arithmetic_branch import ArithmeticBranch
+from obfuscapk.obfuscators.arithmetic_branch.arithmetic_branch import ArithmeticBranch

--- a/src/obfuscapk/obfuscators/asset_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/asset_encryption/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .asset_encryption import AssetEncryption
+from obfuscapk.obfuscators.asset_encryption.asset_encryption import AssetEncryption

--- a/src/obfuscapk/obfuscators/call_indirection/__init__.py
+++ b/src/obfuscapk/obfuscators/call_indirection/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .call_indirection import CallIndirection
+from obfuscapk.obfuscators.call_indirection.call_indirection import CallIndirection

--- a/src/obfuscapk/obfuscators/class_rename/__init__.py
+++ b/src/obfuscapk/obfuscators/class_rename/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .class_rename import ClassRename
+from obfuscapk.obfuscators.class_rename.class_rename import ClassRename

--- a/src/obfuscapk/obfuscators/const_string_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/const_string_encryption/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .const_string_encryption import ConstStringEncryption
+from obfuscapk.obfuscators.const_string_encryption.const_string_encryption import ConstStringEncryption

--- a/src/obfuscapk/obfuscators/debug_removal/__init__.py
+++ b/src/obfuscapk/obfuscators/debug_removal/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .debug_removal import DebugRemoval
+from obfuscapk.obfuscators.debug_removal.debug_removal import DebugRemoval

--- a/src/obfuscapk/obfuscators/field_rename/__init__.py
+++ b/src/obfuscapk/obfuscators/field_rename/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .field_rename import FieldRename
+from obfuscapk.obfuscators.field_rename.field_rename import FieldRename

--- a/src/obfuscapk/obfuscators/goto/__init__.py
+++ b/src/obfuscapk/obfuscators/goto/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .goto import Goto
+from obfuscapk.obfuscators.goto.goto import Goto

--- a/src/obfuscapk/obfuscators/lib_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/lib_encryption/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .lib_encryption import LibEncryption
+from obfuscapk.obfuscators.lib_encryption.lib_encryption import LibEncryption

--- a/src/obfuscapk/obfuscators/method_overload/__init__.py
+++ b/src/obfuscapk/obfuscators/method_overload/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .method_overload import MethodOverload
+from obfuscapk.obfuscators.method_overload.method_overload import MethodOverload

--- a/src/obfuscapk/obfuscators/method_rename/__init__.py
+++ b/src/obfuscapk/obfuscators/method_rename/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .method_rename import MethodRename
+from obfuscapk.obfuscators.method_rename.method_rename import MethodRename

--- a/src/obfuscapk/obfuscators/new_alignment/__init__.py
+++ b/src/obfuscapk/obfuscators/new_alignment/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .new_alignment import NewAlignment
+from obfuscapk.obfuscators.new_alignment.new_alignment import NewAlignment

--- a/src/obfuscapk/obfuscators/new_signature/__init__.py
+++ b/src/obfuscapk/obfuscators/new_signature/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .new_signature import NewSignature
+from obfuscapk.obfuscators.new_signature.new_signature import NewSignature

--- a/src/obfuscapk/obfuscators/nop/__init__.py
+++ b/src/obfuscapk/obfuscators/nop/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .nop import Nop
+from obfuscapk.obfuscators.nop.nop import Nop

--- a/src/obfuscapk/obfuscators/random_manifest/__init__.py
+++ b/src/obfuscapk/obfuscators/random_manifest/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .random_manifest import RandomManifest
+from obfuscapk.obfuscators.random_manifest.random_manifest import RandomManifest

--- a/src/obfuscapk/obfuscators/rebuild/__init__.py
+++ b/src/obfuscapk/obfuscators/rebuild/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .rebuild import Rebuild
+from obfuscapk.obfuscators.rebuild.rebuild import Rebuild

--- a/src/obfuscapk/obfuscators/reflection/__init__.py
+++ b/src/obfuscapk/obfuscators/reflection/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .reflection import Reflection
+from obfuscapk.obfuscators.reflection.reflection import Reflection

--- a/src/obfuscapk/obfuscators/reorder/__init__.py
+++ b/src/obfuscapk/obfuscators/reorder/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .reorder import Reorder
+from obfuscapk.obfuscators.reorder.reorder import Reorder

--- a/src/obfuscapk/obfuscators/res_string_encryption/__init__.py
+++ b/src/obfuscapk/obfuscators/res_string_encryption/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .res_string_encryption import ResStringEncryption
+from obfuscapk.obfuscators.res_string_encryption.res_string_encryption import ResStringEncryption

--- a/src/obfuscapk/obfuscators/virus_total/__init__.py
+++ b/src/obfuscapk/obfuscators/virus_total/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-from .virus_total import VirusTotal
+from obfuscapk.obfuscators.virus_total.virus_total import VirusTotal

--- a/src/obfuscapk/tool.py
+++ b/src/obfuscapk/tool.py
@@ -83,9 +83,9 @@ class Apktool(object):
 
         decode_cmd: List[str] = [
             self.apktool_path,
+            "d",
             "--frame-path",
             tempfile.gettempdir(),
-            "d",
             apk_path,
             "-o",
             output_dir_path,
@@ -145,10 +145,10 @@ class Apktool(object):
 
         build_cmd: List[str] = [
             self.apktool_path,
+            "b",
             "--frame-path",
             tempfile.gettempdir(),
-            "b",
-            "--force-all",
+            "--force",
             source_dir_path,
             "-o",
             output_apk_path,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,4 +2,4 @@ pycryptodome==3.12.0
 pytest-cov==3.0.0
 tqdm==4.62.3
 vt-py==0.13.0
-Yapsy==1.12.2
+Yapsy @ git+https://github.com/Andrew0133/yapsy.git@master#subdirectory=package

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,4 +2,3 @@ pycryptodome==3.12.0
 pytest-cov==3.0.0
 tqdm==4.62.3
 vt-py==0.13.0
-Yapsy @ git+https://github.com/Andrew0133/yapsy.git@master#subdirectory=package

--- a/src/yapsy/AutoInstallPluginManager.py
+++ b/src/yapsy/AutoInstallPluginManager.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+Defines plugin managers that can handle the installation of plugin
+files into the right place. Then the end-user does not have to browse
+to the plugin directory to install them.
+
+API
+===
+"""
+
+import os
+import shutil
+import zipfile
+
+from yapsy.IPlugin import IPlugin
+from yapsy.PluginManagerDecorator import PluginManagerDecorator
+from yapsy import log
+from io import StringIO
+
+
+class AutoInstallPluginManager(PluginManagerDecorator):
+	"""
+	A plugin manager that also manages the installation of the plugin
+	files into the appropriate directory.
+
+	Ctor Arguments:
+		
+	    ``plugin_install_dir``
+  	    The directory where new plugins to be installed will be copied.
+
+	.. warning:: If ``plugin_install_dir`` does not correspond to
+	             an element of the ``directories_list``, it is
+	             appended to the later.			
+	"""
+
+
+	def __init__(self,
+				 plugin_install_dir=None,
+				 decorated_manager=None,
+				 # The following args will only be used if we need to
+				 # create a default PluginManager
+				 categories_filter=None, 
+				 directories_list=None, 
+				 plugin_info_ext="yapsy-plugin"):
+		if categories_filter is None:
+			categories_filter = {"Default":IPlugin}
+		# Create the base decorator class
+		PluginManagerDecorator.__init__(self,
+										decorated_manager,
+										categories_filter,
+										directories_list,
+										plugin_info_ext)
+		# set the directory for new plugins
+		self.plugins_places=[]
+		self.setInstallDir(plugin_install_dir)
+
+	def setInstallDir(self,plugin_install_dir):
+		"""
+		Set the directory where to install new plugins.
+		"""
+		if not (plugin_install_dir in self.plugins_places):
+			self.plugins_places.append(plugin_install_dir)
+		self.install_dir = plugin_install_dir
+
+	def getInstallDir(self):
+		"""
+		Return the directory where new plugins should be installed.
+		"""
+		return self.install_dir
+
+	def install(self, directory, plugin_info_filename):
+		"""
+		Giving the plugin's info file (e.g. ``myplugin.yapsy-plugin``),
+		and the directory where it is located, get all the files that
+		define the plugin and copy them into the correct directory.
+		
+		Return ``True`` if the installation is a success, ``False`` if
+		it is a failure.
+		"""
+		# start collecting essential info about the new plugin
+		plugin_info, config_parser = self._gatherCorePluginInfo(directory, plugin_info_filename)
+		# now determine the path of the file to execute,
+		# depending on wether the path indicated is a
+		# directory or a file
+		if not (os.path.exists(plugin_info.path) or os.path.exists(plugin_info.path+".py") ):
+			log.warning("Could not find the plugin's implementation for %s." % plugin_info.name)
+			return False
+		if os.path.isdir(plugin_info.path):
+			try:
+				shutil.copytree(plugin_info.path,
+								os.path.join(self.install_dir,os.path.basename(plugin_info.path)))
+				shutil.copy(os.path.join(directory, plugin_info_filename),
+							self.install_dir)
+			except:
+				log.error("Could not install plugin: %s." % plugin_info.name)
+				return False
+			else:
+				return True
+		elif os.path.isfile(plugin_info.path+".py"):
+			try:
+				shutil.copy(plugin_info.path+".py",
+							self.install_dir)
+				shutil.copy(os.path.join(directory, plugin_info_filename),
+						   self.install_dir)
+			except:
+				log.error("Could not install plugin: %s." % plugin_info.name)
+				return False
+			else:
+				return True
+		else:
+			return False
+		
+		
+	def installFromZIP(self, plugin_ZIP_filename):
+		"""
+		Giving the plugin's zip file (e.g. ``myplugin.zip``), check
+		that their is a valid info file in it and correct all the
+		plugin files into the correct directory.
+		
+		.. warning:: Only available for python 2.6 and later.
+		
+		Return ``True`` if the installation is a success, ``False`` if
+		it is a failure.
+		"""
+		if not os.path.isfile(plugin_ZIP_filename):
+			log.warning("Could not find the plugin's zip file at '%s'." % plugin_ZIP_filename)
+			return False
+		try:
+			candidateZipFile = zipfile.ZipFile(plugin_ZIP_filename)
+			first_bad_file = candidateZipFile.testzip()
+			if first_bad_file:
+				raise Exception("Corrupted ZIP with first bad file '%s'" % first_bad_file)
+		except Exception as e:
+			log.warning("Invalid zip file '%s' (error: %s)." % (plugin_ZIP_filename,e))
+			return False
+		zipContent = candidateZipFile.namelist()
+		log.info("Investigating the content of a zip file containing: '%s'" % zipContent)
+		log.info("Sanity checks on zip's contained files (looking for hazardous path symbols).")	
+		# check absence of root path and ".." shortcut that would
+		# send the file oustide the desired directory
+		for containedFileName in zipContent:
+			# WARNING: the sanity checks below are certainly not
+			# exhaustive (maybe we could do something a bit smarter by
+			# using os.path.expanduser, os.path.expandvars and
+			# os.path.normpath)
+			if containedFileName.startswith("/"):
+				log.warning("Unsecure zip file, rejected because one of its file paths ('%s') starts with '/'" % containedFileName)
+				return False
+			if containedFileName.startswith(r"\\") or containedFileName.startswith("//"):
+				log.warning(r"Unsecure zip file, rejected because one of its file paths ('%s') starts with '\\'" % containedFileName)
+				return False
+			if os.path.splitdrive(containedFileName)[0]:
+				log.warning("Unsecure zip file, rejected because one of its file paths ('%s') starts with a drive letter" % containedFileName)
+				return False
+			if os.path.isabs(containedFileName):
+				log.warning("Unsecure zip file, rejected because one of its file paths ('%s') is absolute" % containedFileName)
+				return False
+			pathComponent = os.path.split(containedFileName)
+			if ".." in pathComponent:
+				log.warning("Unsecure zip file, rejected because one of its file paths ('%s') contains '..'" % containedFileName)	
+				return False
+			if "~" in pathComponent:
+				log.warning("Unsecure zip file, rejected because one of its file paths ('%s') contains '~'" % containedFileName)	
+				return False
+		infoFileCandidates = [filename for filename in zipContent if os.path.dirname(filename)==""]
+		if not infoFileCandidates:
+			log.warning("Zip file structure seems wrong in '%s', no info file found." % plugin_ZIP_filename)
+			return False
+		isValid = False
+		log.info("Looking for the zipped plugin's info file among '%s'" % infoFileCandidates)
+		for infoFileName in infoFileCandidates:
+			infoFile = candidateZipFile.read(infoFileName)
+			log.info("Assuming the zipped plugin info file to be '%s'" % infoFileName)
+			pluginName,moduleName,_ = self._getPluginNameAndModuleFromStream(StringIO(str(infoFile,encoding="utf-8")))
+			if moduleName is None:
+					continue
+			log.info("Checking existence of the expected module '%s' in the zip file" % moduleName)
+			candidate_module_paths = [
+				moduleName,
+				# Try path consistent with the platform specific one
+				os.path.join(moduleName,"__init__.py"),
+				# Try typical paths (unix and windows)
+				"%s/__init__.py" % moduleName,
+				"%s\\__init__.py" % moduleName
+				]
+			for candidate in candidate_module_paths:
+				if candidate in zipContent:
+					isValid = True
+					break
+			if isValid:
+				break
+		if not isValid:
+			log.warning("Zip file structure seems wrong in '%s', "
+							"could not match info file with the implementation of plugin '%s'." % (plugin_ZIP_filename,pluginName))
+			return False
+		else:
+			try:
+				candidateZipFile.extractall(self.install_dir)
+				return True
+			except Exception as e:
+				log.error("Could not install plugin '%s' from zip file '%s' (exception: '%s')." % (pluginName,plugin_ZIP_filename,e))
+				return False
+		

--- a/src/yapsy/ConfigurablePluginManager.py
+++ b/src/yapsy/ConfigurablePluginManager.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+Defines plugin managers that can handle configuration files similar to
+the ini files manipulated by Python's ConfigParser module.
+
+API
+===
+"""
+
+from yapsy.IPlugin import IPlugin
+
+
+from yapsy.PluginManagerDecorator import PluginManagerDecorator
+from yapsy.PluginManager import PLUGIN_NAME_FORBIDEN_STRING
+	
+
+class ConfigurablePluginManager(PluginManagerDecorator):
+	"""
+	A plugin manager that also manages a configuration file.
+
+	The configuration file will be accessed through a ``ConfigParser``
+	derivated object. The file can be used for other purpose by the
+	application using this plugin manager as it will only add a new
+	specific section ``[Plugin Management]`` for itself and also new
+	sections for some plugins that will start with ``[Plugin:...]``
+	(only the plugins that explicitly requires to save configuration
+	options will have this kind of section).
+
+	.. warning:: when giving/building the list of plugins to activate
+	             by default, there must not be any space in the list
+	             (neither in the names nor in between)
+
+	The ``config_change_trigger`` argument can be used to set a
+	specific method to call when the configuration is
+	altered. This will let the client application manage the way
+	they want the configuration to be updated (e.g. write on file
+	at each change or at precise time intervalls or whatever....)
+	
+	.. warning:: when no ``config_change_trigger`` is given and if
+	             the provided ``configparser_instance`` doesn't handle it
+	             implicitely, recording the changes persistently (ie writing on 
+	             the config file) won't happen.
+	"""
+	
+	CONFIG_SECTION_NAME = "Plugin Management"
+
+
+	def __init__(self,
+				 configparser_instance=None,
+				 config_change_trigger= lambda :True,
+				 decorated_manager=None,
+				 # The following args will only be used if we need to
+				 # create a default PluginManager
+				 categories_filter=None, 
+				 directories_list=None, 
+				 plugin_info_ext="yapsy-plugin"):
+		if categories_filter is None:
+			categories_filter = {"Default":IPlugin}
+		# Create the base decorator class
+		PluginManagerDecorator.__init__(self,decorated_manager,
+										categories_filter,
+										directories_list,
+										plugin_info_ext)
+		self.setConfigParser(configparser_instance, config_change_trigger)
+
+
+	def setConfigParser(self,configparser_instance,config_change_trigger):
+		"""
+		Set the ConfigParser instance.
+		"""
+		self.config_parser = configparser_instance
+		# set the (optional) fucntion to be called when the
+		# configuration is changed:
+		self.config_has_changed = config_change_trigger
+		
+	def __getCategoryPluginsListFromConfig(self, plugin_list_str):
+		"""
+		Parse the string describing the list of plugins to activate,
+		to discover their actual names and return them.
+		"""
+		return plugin_list_str.strip(" ").split("%s"%PLUGIN_NAME_FORBIDEN_STRING)
+
+	def __getCategoryPluginsConfigFromList(self, plugin_list):
+		"""
+		Compose a string describing the list of plugins to activate
+		"""
+		return PLUGIN_NAME_FORBIDEN_STRING.join(plugin_list)
+		
+	def __getCategoryOptionsName(self,category_name):
+		"""
+		Return the appropirately formated version of the category's
+		option.
+		"""
+		return "%s_plugins_to_load" % category_name.replace(" ","_")
+
+	def __addPluginToConfig(self,category_name, plugin_name):
+		"""
+		Utility function to add a plugin to the list of plugin to be
+		activated.
+		"""
+		# check that the section is here
+		if not self.config_parser.has_section(self.CONFIG_SECTION_NAME):
+			self.config_parser.add_section(self.CONFIG_SECTION_NAME)
+		# check that the category's list of activated plugins is here too
+		option_name = self.__getCategoryOptionsName(category_name)
+		if not self.config_parser.has_option(self.CONFIG_SECTION_NAME, option_name):
+			# if there is no list yet add a new one
+			self.config_parser.set(self.CONFIG_SECTION_NAME,option_name,plugin_name)
+			return self.config_has_changed()
+		else:
+			# get the already existing list and append the new
+			# activated plugin to it.
+			past_list_str = self.config_parser.get(self.CONFIG_SECTION_NAME,option_name)
+			past_list = self.__getCategoryPluginsListFromConfig(past_list_str)
+			# make sure we don't add it twice
+			if plugin_name not in past_list: 
+				past_list.append(plugin_name)
+				new_list_str = self.__getCategoryPluginsConfigFromList(past_list)
+				self.config_parser.set(self.CONFIG_SECTION_NAME,option_name,new_list_str)
+				return self.config_has_changed()
+
+	def __removePluginFromConfig(self,category_name, plugin_name):
+		"""
+		Utility function to add a plugin to the list of plugin to be
+		activated.
+		"""
+		# check that the section is here
+		if not self.config_parser.has_section(self.CONFIG_SECTION_NAME):
+			# then nothing to remove :)
+			return 
+		# check that the category's list of activated plugins is here too
+		option_name = self.__getCategoryOptionsName(category_name)
+		if not self.config_parser.has_option(self.CONFIG_SECTION_NAME, option_name):
+			# if there is no list still nothing to do
+			return
+		else:
+			# get the already existing list
+			past_list_str = self.config_parser.get(self.CONFIG_SECTION_NAME,option_name)
+			past_list = self.__getCategoryPluginsListFromConfig(past_list_str)
+			if plugin_name in past_list:
+				past_list.remove(plugin_name)
+				new_list_str = self.__getCategoryPluginsConfigFromList(past_list)
+				self.config_parser.set(self.CONFIG_SECTION_NAME,option_name,new_list_str)
+				self.config_has_changed()		
+			
+
+
+	def registerOptionFromPlugin(self, 
+								 category_name, plugin_name, 
+								 option_name, option_value):
+		"""
+		To be called from a plugin object, register a given option in
+		the name of a given plugin.
+		"""
+		section_name = "%s Plugin: %s" % (category_name,plugin_name)
+		# if the plugin's section is not here yet, create it
+		if not self.config_parser.has_section(section_name):
+			self.config_parser.add_section(section_name)
+		# set the required option
+		self.config_parser.set(section_name,option_name,option_value)
+		self.config_has_changed()
+
+	def hasOptionFromPlugin(self, 
+							category_name, plugin_name, option_name):
+		"""
+		To be called from a plugin object, return True if the option
+		has already been registered.
+		"""
+		section_name = "%s Plugin: %s" % (category_name,plugin_name)
+		return self.config_parser.has_section(section_name) and self.config_parser.has_option(section_name,option_name)
+
+	def readOptionFromPlugin(self, 
+							 category_name, plugin_name, option_name):
+		"""
+		To be called from a plugin object, read a given option in
+		the name of a given plugin.
+		"""
+		section_name = "%s Plugin: %s" % (category_name,plugin_name)
+		return self.config_parser.get(section_name,option_name)
+
+
+	def __decoratePluginObject(self, category_name, plugin_name, plugin_object):
+		"""
+		Add two methods to the plugin objects that will make it
+		possible for it to benefit from this class's api concerning
+		the management of the options.
+		"""
+		plugin_object.setConfigOption = lambda x,y: self.registerOptionFromPlugin(category_name,
+																				  plugin_name,
+																				  x,y)
+		plugin_object.setConfigOption.__doc__ = self.registerOptionFromPlugin.__doc__
+		plugin_object.getConfigOption = lambda x: self.readOptionFromPlugin(category_name,
+																			plugin_name,
+																			x)
+		plugin_object.getConfigOption.__doc__ = self.readOptionFromPlugin.__doc__
+		plugin_object.hasConfigOption = lambda x: self.hasOptionFromPlugin(category_name,
+																		   plugin_name,
+																		   x)
+		plugin_object.hasConfigOption.__doc__ = self.hasOptionFromPlugin.__doc__
+
+	def activatePluginByName(self, plugin_name, category_name="Default", save_state=True):
+		"""
+		Activate a plugin, , and remember it (in the config file).
+
+		If you want the plugin to benefit from the configuration
+		utility defined by this manager, it is crucial to use this
+		method to activate a plugin and not call the plugin object's
+		``activate`` method. In fact, this method will also "decorate"
+		the plugin object so that it can use this class's methods to
+		register its own options.
+		
+		By default, the plugin's activation is registered in the
+		config file but if you d'ont want this set the 'save_state'
+		argument to False.
+		"""
+		# first decorate the plugin
+		pta = self._component.getPluginByName(plugin_name,category_name)
+		if pta is None:
+			return None
+		self.__decoratePluginObject(category_name,plugin_name,pta.plugin_object)		
+		# activate the plugin
+		plugin_object = self._component.activatePluginByName(plugin_name,category_name)
+		# check the activation and then optionally set the config option
+		if plugin_object.is_activated:
+			if save_state:
+				self.__addPluginToConfig(category_name,plugin_name)
+			return plugin_object
+		return None
+
+	def deactivatePluginByName(self, plugin_name, category_name="Default", save_state=True):
+		"""
+		Deactivate a plugin, and remember it (in the config file).
+
+		By default, the plugin's deactivation is registered in the
+		config file but if you d'ont want this set the ``save_state``
+		argument to False.
+		"""
+		# activate the plugin
+		plugin_object = self._component.deactivatePluginByName(plugin_name,category_name)
+		if plugin_object is None:
+			return None
+		# check the deactivation and then optionnally set the config option
+		if not plugin_object.is_activated:
+			if save_state:
+				self.__removePluginFromConfig(category_name,plugin_name)
+				return plugin_object
+		return None
+
+	def loadPlugins(self,callback=None, callback_after=None):
+		"""
+		Walk through the plugins' places and look for plugins.  Then
+		for each plugin candidate look for its category, load it and
+		stores it in the appropriate slot of the ``category_mapping``.
+		"""
+		self._component.loadPlugins(callback, callback_after)
+		# now load the plugins according to the recorded configuration
+		if self.config_parser.has_section(self.CONFIG_SECTION_NAME):
+			# browse all the categories
+			for category_name in list(self._component.category_mapping.keys()):
+				# get the list of plugins to be activated for this
+				# category
+				option_name = "%s_plugins_to_load"%category_name
+				if self.config_parser.has_option(self.CONFIG_SECTION_NAME,
+												 option_name):
+					plugin_list_str = self.config_parser.get(self.CONFIG_SECTION_NAME,
+															 option_name)
+					plugin_list = self.__getCategoryPluginsListFromConfig(plugin_list_str)
+					# activate all the plugins that should be
+					# activated
+					for plugin_name in plugin_list:
+						self.activatePluginByName(plugin_name,category_name)
+
+				
+
+		

--- a/src/yapsy/FilteredPluginManager.py
+++ b/src/yapsy/FilteredPluginManager.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+Defines the basic mechanisms to have a plugin manager filter the
+available list of plugins after locating them and before loading them.
+
+One use fo this would be to prevent untrusted plugins from entering
+the system.
+
+To use it properly you must reimplement or monkey patch the
+``IsPluginOk`` method, as in the following example::
+
+  # define a plugin manager (with you prefered options)
+  pm = PluginManager(...)
+  # decorate it with the Filtering mechanics
+  pm = FilteredPluginManager(pm)
+  # define a custom predicate that filters out plugins without descriptions
+  pm.isPluginOk = lambda x: x.description!=""
+
+
+API
+===
+"""
+ 
+
+from yapsy.IPlugin import IPlugin
+from yapsy.PluginManagerDecorator import  PluginManagerDecorator
+
+
+class FilteredPluginManager(PluginManagerDecorator):
+	"""
+	Base class for decorators which filter the plugins list
+	before they are loaded.
+	"""
+
+	def __init__(self, 
+				 decorated_manager=None,
+				 categories_filter=None, 
+				 directories_list=None, 
+				 plugin_info_ext="yapsy-plugin"):
+		if categories_filter is None:
+			categories_filter = {"Default":IPlugin}
+		# Create the base decorator class
+		PluginManagerDecorator.__init__(self,decorated_manager,
+										categories_filter,
+										directories_list,
+										plugin_info_ext)
+		# prepare the mapping of the latest version of each plugin
+		self.rejectedPlugins =  [ ] 
+
+
+
+	def filterPlugins(self):
+		"""
+		Go through the currently available candidates, and and either
+		leaves them, or moves them into the list of rejected Plugins.
+		
+		Can be overridden if overriding ``isPluginOk`` sentinel is not
+		powerful enough.
+		"""
+		self.rejectedPlugins = [ ]
+		for candidate_infofile, candidate_filepath, plugin_info in self._component.getPluginCandidates():
+			if not self.isPluginOk( plugin_info):
+				self.rejectPluginCandidate((candidate_infofile, candidate_filepath, plugin_info) )
+
+	def rejectPluginCandidate(self,pluginTuple):
+		"""
+		Move a plugin from the candidates list to the rejected List.
+		"""
+		if pluginTuple in self.getPluginCandidates():
+			self._component.removePluginCandidate(pluginTuple)
+		if not pluginTuple in self.rejectedPlugins:
+			self.rejectedPlugins.append(pluginTuple)
+
+	def unrejectPluginCandidate(self,pluginTuple):
+		"""
+		Move a plugin from the rejected list to into the candidates
+		list.
+		"""
+		if not pluginTuple in self.getPluginCandidates():
+			self._component.appendPluginCandidate(pluginTuple)
+		if pluginTuple in self.rejectedPlugins:
+			self.rejectedPlugins.remove(pluginTuple)
+
+	def removePluginCandidate(self,pluginTuple):
+		"""
+		Remove a plugin from the list of candidates.
+		"""
+		if pluginTuple in self.getPluginCandidates():
+			self._component.removePluginCandidate(pluginTuple)
+		if  pluginTuple in self.rejectedPlugins:
+			self.rejectedPlugins.remove(pluginTuple)
+
+
+	def appendPluginCandidate(self,pluginTuple):
+		"""
+		Add a new candidate.
+		"""
+		if self.isPluginOk(pluginTuple[2]):
+			if pluginTuple not in self.getPluginCandidates():
+				self._component.appendPluginCandidate(pluginTuple)
+		else:
+			if not pluginTuple in self.rejectedPlugins:
+				self.rejectedPlugins.append(pluginTuple)
+
+	def isPluginOk(self,info):
+		"""
+		Sentinel function to detect if a plugin should be filtered.
+
+		``info`` is an instance of a ``PluginInfo`` and this method is
+		expected to return True if the corresponding plugin can be
+		accepted, and False if it must be filtered out.
+		
+		Subclasses should override this function and return false for
+		any plugin which they do not want to be loadable.
+		"""
+		return True
+
+	def locatePlugins(self):
+		"""
+		locate and filter plugins.
+		"""
+		#Reset Catalogue
+		self.setCategoriesFilter(self._component.categories_interfaces)
+		#Reread and filter.
+		self._component.locatePlugins()
+		self.filterPlugins()
+		return len(self._component.getPluginCandidates()) 
+
+	def getRejectedPlugins(self):
+		"""
+		Return the list of rejected plugins.
+		"""
+		return self.rejectedPlugins[:]

--- a/src/yapsy/IMultiprocessChildPlugin.py
+++ b/src/yapsy/IMultiprocessChildPlugin.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+Originally defined the basic interfaces for multiprocessed plugins.
+
+Deprecation Note
+================
+
+This class is deprecated and replaced by :doc:`IMultiprocessChildPlugin`.
+
+Child classes of `IMultiprocessChildPlugin` used to be an `IPlugin` as well as
+a `multiprocessing.Process`, possibly playing with the functionalities of both,
+which make maintenance harder than necessary.
+
+And indeed following a bug fix to make multiprocess plugins work on Windows,
+instances of IMultiprocessChildPlugin inherit Process but are not exactly the
+running process (there is a new wrapper process).
+
+API
+===
+"""
+
+from multiprocessing import Process
+from yapsy.IMultiprocessPlugin import IMultiprocessPlugin
+
+
+class IMultiprocessChildPlugin(IMultiprocessPlugin, Process):
+	"""
+	Base class for multiprocessed plugin.
+
+	DEPRECATED(>1.11): Please use IMultiProcessPluginBase instead !
+	"""
+
+	def __init__(self, parent_pipe):
+		IMultiprocessPlugin.__init__(self, parent_pipe)
+		Process.__init__(self)
+
+	def run(self):
+		"""
+		Override this method in your implementation
+		"""
+		return

--- a/src/yapsy/IMultiprocessPlugin.py
+++ b/src/yapsy/IMultiprocessPlugin.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+Defines the basic interfaces for multiprocessed plugins.
+
+Extensibility
+=============
+
+In your own software, you'll probably want to build derived classes of
+the ``IMultiprocessPlugin`` class as it is a mere interface with no specific
+functionality.
+
+Your software's plugins should then inherit your very own plugin class
+(itself derived from ``IMultiprocessPlugin``).
+
+Override the `run` method to include your code. Use the `self.parent_pipe` to send
+and receive data with the parent process or create your own communication
+mecanism.
+
+Where and how to code these plugins is explained in the section about
+the :doc:`PluginManager`.
+
+API
+===
+"""
+
+from yapsy.IPlugin import IPlugin
+
+
+class IMultiprocessPlugin(IPlugin):
+	"""
+	Base class for multiprocessed plugin.
+	"""
+
+	def __init__(self, parent_pipe):
+		IPlugin.__init__(self)
+		self.parent_pipe = parent_pipe
+
+	def run(self):
+		"""
+		Override this method in your implementation
+		"""
+		return

--- a/src/yapsy/IPlugin.py
+++ b/src/yapsy/IPlugin.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+Defines the basic interfaces for a plugin. These interfaces are
+inherited by the *core* class of a plugin. The *core* class of a
+plugin is then the one that will be notified the
+activation/deactivation of a plugin via the ``activate/deactivate``
+methods.
+
+
+For simple (near trivial) plugin systems, one can directly use the
+following interfaces.
+
+Extensibility
+=============
+
+In your own software, you'll probably want to build derived classes of
+the ``IPlugin`` class as it is a mere interface with no specific
+functionality.
+
+Your software's plugins should then inherit your very own plugin class
+(itself derived from ``IPlugin``).
+
+Where and how to code these plugins is explained in the section about
+the :doc:`PluginManager`.
+
+
+API
+===
+"""
+
+
+class IPlugin(object):
+	"""
+	The most simple interface to be inherited when creating a plugin.
+	"""
+
+	def __init__(self):
+		self.is_activated = False
+
+	def activate(self):
+		"""
+		Called at plugin activation.
+		"""
+		self.is_activated = True
+
+	def deactivate(self):
+		"""
+		Called when the plugin is disabled.
+		"""
+		self.is_activated = False
+

--- a/src/yapsy/IPluginLocator.py
+++ b/src/yapsy/IPluginLocator.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+
+"""
+Role
+====
+
+``IPluginLocator`` defines the basic interface expected by a
+``PluginManager`` to be able to locate plugins and get basic info
+about each discovered plugin (name, version etc).
+
+API
+===
+
+"""
+
+
+from yapsy import log
+
+class IPluginLocator(object):
+	"""
+	Plugin Locator interface with some methods already implemented to
+	manage the awkward backward compatible stuff.
+	"""
+	
+	def locatePlugins(self):
+		"""
+		Walk through the plugins' places and look for plugins.
+
+		Return the discovered plugins as a list of
+		``(candidate_infofile_path, candidate_file_path,plugin_info_instance)``
+		and their number.
+		"""
+		raise NotImplementedError("locatePlugins must be reimplemented by %s" % self)
+	
+	def gatherCorePluginInfo(self, directory, filename):
+		"""
+		Return a ``PluginInfo`` as well as the ``ConfigParser`` used to build it.
+		
+		If filename is a valid plugin discovered by any of the known
+		strategy in use. Returns None,None otherwise.
+		"""
+		raise NotImplementedError("gatherPluginInfo must be reimplemented by %s" % self)
+	
+	# --------------------------------------------------------------------
+	# Below are backward compatibility methods: if you inherit from
+	# IPluginLocator it's ok not to reimplement them, there will only
+	# be a warning message logged if they are called and not
+	# reimplemented.
+	# --------------------------------------------------------------------
+	
+	def getPluginNameAndModuleFromStream(self,fileobj):
+		"""
+		DEPRECATED(>1.9): kept for backward compatibility
+		with existing PluginManager child classes.
+		
+		Return a 3-uple with the name of the plugin, its
+		module and the config_parser used to gather the core
+		data *in a tuple*, if the required info could be
+		localised, else return ``(None,None,None)``.
+		"""
+		log.warning("setPluginInfoClass was called but '%s' doesn't implement it." % self)
+		return None,None,None
+	
+
+	def setPluginInfoClass(self, picls, names=None):
+		"""
+		DEPRECATED(>1.9): kept for backward compatibility
+		with existing PluginManager child classes.
+		
+		Set the class that holds PluginInfo. The class should inherit
+		from ``PluginInfo``.
+		"""
+		log.warning("setPluginInfoClass was called but '%s' doesn't implement it." % self)
+
+	def getPluginInfoClass(self):
+		"""
+		DEPRECATED(>1.9): kept for backward compatibility
+		with existing PluginManager child classes.
+		
+		Get the class that holds PluginInfo.
+		"""
+		log.warning("getPluginInfoClass was called but '%s' doesn't implement it." % self)
+		return None
+
+	def setPluginPlaces(self, directories_list):
+		"""
+		DEPRECATED(>1.9): kept for backward compatibility
+		with existing PluginManager child classes.
+		
+		Set the list of directories where to look for plugin places.
+		"""
+		log.warning("setPluginPlaces was called but '%s' doesn't implement it." % self)
+
+	def updatePluginPlaces(self, directories_list):
+		"""
+		DEPRECATED(>1.9): kept for backward compatibility
+		with existing PluginManager child classes.
+		
+		Updates the list of directories where to look for plugin places.
+		"""
+		log.warning("updatePluginPlaces was called but '%s' doesn't implement it." % self)
+

--- a/src/yapsy/MultiprocessPluginManager.py
+++ b/src/yapsy/MultiprocessPluginManager.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+Defines a plugin manager that runs all plugins in separate process
+linked by pipes.
+
+
+API
+===
+"""
+
+import multiprocessing as mproc
+
+from yapsy.IMultiprocessPlugin import IMultiprocessPlugin
+from yapsy.IMultiprocessChildPlugin import IMultiprocessChildPlugin
+from yapsy.MultiprocessPluginProxy import MultiprocessPluginProxy
+from yapsy.PluginManager import  PluginManager
+
+
+class MultiprocessPluginManager(PluginManager):
+	"""
+	Subclass of the PluginManager that runs each plugin in a different process
+	"""	
+
+	def __init__(self,
+				 categories_filter=None,
+				 directories_list=None,
+				 plugin_info_ext=None,
+				 plugin_locator=None):
+		if categories_filter is None:
+			categories_filter = {"Default": IMultiprocessPlugin}
+		PluginManager.__init__(self,
+								 categories_filter=categories_filter,
+								 directories_list=directories_list,
+								 plugin_info_ext=plugin_info_ext,
+								 plugin_locator=plugin_locator)
+		self.connections = []
+
+		
+	def instanciateElementWithImportInfo(self, element, element_name,
+										 plugin_module_name, candidate_filepath):
+		"""This method instanciates each plugin in a new process and links it to
+		the parent with a pipe.
+
+		In the parent process context, the plugin's class is replaced by
+		the ``MultiprocessPluginProxy`` class that hold the information
+		about the child process and the pipe to communicate with it.
+
+		.. warning:: 
+		    The plugin code should only use the pipe to
+			communicate with the rest of the applica`tion and should not
+			assume any kind of shared memory, not any specific functionality
+			of the `multiprocessing.Process` parent class (its behaviour is
+			different between platforms !)
+		
+		See ``IMultiprocessPlugin``.
+		"""
+		if element is IMultiprocessChildPlugin:
+			# The following will keep retro compatibility for IMultiprocessChildPlugin
+			raise Exception("Preventing instanciation of a bar child plugin interface.")
+		instanciated_element = MultiprocessPluginProxy()
+		parent_pipe, child_pipe = mproc.Pipe()
+		instanciated_element.child_pipe = parent_pipe
+		instanciated_element.proc = MultiprocessPluginManager._PluginProcessWrapper(
+			element_name, plugin_module_name, candidate_filepath,
+			child_pipe)
+		instanciated_element.proc.start()
+		return instanciated_element
+
+
+	class _PluginProcessWrapper(mproc.Process):
+		"""Helper class that strictly needed to be able to spawn the
+		plugin on Windows but kept also for Unix platform to get a more
+		uniform behaviour.
+
+		This will handle re-importing the plugin's module in the child
+		process (again this is necessary on windows because what has
+		been imported in the main thread/process will not be shared with
+		the spawned process.)
+		"""
+		def __init__(self, element_name, plugin_module_name, candidate_filepath, child_pipe):
+			self.element_name = element_name
+			self.child_pipe = child_pipe
+			self.plugin_module_name = plugin_module_name
+			self.candidate_filepath = candidate_filepath
+			mproc.Process.__init__(self)
+	 
+		def run(self):
+			module = PluginManager._importModule(self.plugin_module_name,
+												 self.candidate_filepath)
+			element = getattr(module, self.element_name)
+			e = element(self.child_pipe)
+			e.run()

--- a/src/yapsy/MultiprocessPluginProxy.py
+++ b/src/yapsy/MultiprocessPluginProxy.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+The ``MultiprocessPluginProxy`` is instanciated by the MultiprocessPluginManager to replace the real implementation
+that is run in a different process.
+
+You cannot access your plugin directly from the parent process. You should use the child_pipe to communicate
+with your plugin. The `MultiprocessPluginProxy`` role is to keep reference of the communication pipe to the
+child process as well as the process informations.
+
+API
+===
+"""
+
+from yapsy.IPlugin import IPlugin
+
+
+class MultiprocessPluginProxy(IPlugin):
+	"""
+	This class contains two members that are initialized by the :doc:`MultiprocessPluginManager`.
+
+	self.proc is a reference that holds the multiprocessing.Process instance of the child process.
+
+	self.child_pipe is a reference that holds the multiprocessing.Pipe instance to communicate with the child.
+	"""
+	def __init__(self):
+		IPlugin.__init__(self)
+		self.proc = None		# This attribute holds the multiprocessing.Process instance
+		self.child_pipe = None  # This attribute holds the multiprocessing.Pipe instance

--- a/src/yapsy/PluginFileLocator.py
+++ b/src/yapsy/PluginFileLocator.py
@@ -1,0 +1,538 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+The ``PluginFileLocator`` locates plugins when they are accessible via the filesystem.
+
+It's default behaviour is to look for text files with the
+'.yapsy-plugin' extensions and to read the plugin's decription in
+them.
+
+
+Customization
+-------------
+
+The behaviour of a ``PluginFileLocator`` can be customized by instanciating it with a specific 'analyzer'.
+
+Two analyzers are already implemented and provided here:
+
+    ``PluginFileAnalyzerWithInfoFile``
+
+        the default 'analyzer' that looks for plugin 'info files' as
+        text file with a predefined extension. This implements the way
+        yapsy looks for plugin since version 1.
+
+    ``PluginFileAnalyzerMathingRegex``
+
+        look for files matching a regex and considers them as being
+        the plugin itself.
+
+All analyzers must enforce the 
+
+It enforces the ``plugin locator`` policy as defined by ``IPluginLocator`` and used by ``PluginManager``.
+
+    ``info_ext``
+
+        expects a plugin to be discovered through its *plugin info file*.
+        User just needs to provide an extension (without '.') to look
+        for *plugin_info_file*.
+
+    ``regexp``
+
+        looks for file matching the given regular pattern expression.
+        User just needs to provide the regular pattern expression.
+
+All analyzers must enforce the policy represented by the ``IPluginFileAnalyzer`` interface.
+
+
+API
+===
+
+"""
+
+import os
+import re
+from configparser import ConfigParser
+
+from yapsy import log
+
+from yapsy.PluginInfo import PluginInfo
+from yapsy import PLUGIN_NAME_FORBIDEN_STRING
+from yapsy.IPluginLocator import IPluginLocator
+
+
+_BASIC_STRING_CLASSES = (str, bytes)
+
+
+class IPluginFileAnalyzer(object):
+	"""
+	Define the methods expected by PluginFileLocator for its 'analyzer'.
+	"""
+
+	def __init__(self,name):
+		self.name = name
+	
+	def isValidPlugin(self, filename):
+		"""
+		Check if the resource found at filename is a valid plugin.
+		"""
+		raise NotImplementedError("'isValidPlugin' must be reimplemented by %s" % self)	
+
+
+	def getInfosDictFromPlugin(self, dirpath, filename):
+		"""
+		Returns the extracted plugin informations as a dictionary.
+		This function ensures that "name" and "path" are provided.
+
+		*dirpath* is the full path to the directory where the plugin file is
+
+		*filename* is the name (ie the basename) of the plugin file.
+		
+		If *callback* function has not been provided for this strategy,
+		we use the filename alone to extract minimal informations.
+		"""
+		raise NotImplementedError("'getInfosDictFromPlugin' must be reimplemented by %s" % self)
+
+
+class PluginFileAnalyzerWithInfoFile(IPluginFileAnalyzer):
+	"""
+	Consider plugins described by a textual description file.
+
+	A plugin is expected to be described by a text file ('ini' format) with a specific extension (.yapsy-plugin by default).
+
+	This file must contain at least the following information::
+	
+	    [Core]
+	    Name = name of the module
+	    Module = relative_path/to/python_file_or_directory
+
+	Optionnally the description file may also contain the following section (in addition to the above one)::
+
+	    [Documentation]
+	    Author = Author Name
+	    Version = Major.minor
+	    Website = url_for_plugin
+	    Description = A simple one-sentence description
+
+	Ctor Arguments:
+		
+		*name* name of the analyzer.
+
+		*extensions* the expected extensions for the plugin info file. May be a string or a tuple of strings if several extensions are expected.
+	"""
+	
+	def __init__(self, name, extensions="yapsy-plugin"):
+		IPluginFileAnalyzer.__init__(self,name)
+		self.setPluginInfoExtension(extensions)
+
+	
+	def setPluginInfoExtension(self,extensions):
+		"""
+		Set the extension that will identify a plugin info file.
+
+		*extensions* May be a string or a tuple of strings if several extensions are expected.
+		"""
+		# Make sure extension is a tuple
+		if not isinstance(extensions, tuple):
+			extensions = (extensions, )
+		self.expectedExtensions = extensions
+		
+	
+	def isValidPlugin(self, filename):
+		"""
+		Check if it is a valid plugin based on the given plugin info file extension(s).
+		If several extensions are provided, the first matching will cause the function
+		to exit successfully.
+		"""
+		res = False
+		for ext in self.expectedExtensions:
+			if filename.endswith(".%s" % ext):
+				res = True
+				break
+		return res
+	
+	def getPluginNameAndModuleFromStream(self, infoFileObject, candidate_infofile=None):
+		"""
+		Extract the name and module of a plugin from the
+		content of the info file that describes it and which
+		is stored in ``infoFileObject``.
+		
+		.. note:: Prefer using ``_extractCorePluginInfo``
+		          instead, whenever possible...
+		
+		.. warning:: ``infoFileObject`` must be a file-like object:
+		             either an opened file for instance or a string
+		             buffer wrapped in a StringIO instance as another
+		             example.
+		      
+		.. note:: ``candidate_infofile`` must be provided
+		          whenever possible to get better error messages.
+		
+		Return a 3-uple with the name of the plugin, its
+		module and the config_parser used to gather the core
+		data *in a tuple*, if the required info could be
+		localised, else return ``(None,None,None)``.
+		
+		.. note:: This is supposed to be used internally by subclasses
+			      and decorators.
+		"""
+		# parse the information buffer to get info about the plugin
+		config_parser = ConfigParser()
+		try:
+			config_parser.read_file(infoFileObject)
+		except Exception as e:
+			log.debug("Could not parse the plugin file '%s' (exception raised was '%s')" % (candidate_infofile,e))
+			return (None, None, None)
+		# check if the basic info is available
+		if not config_parser.has_section("Core"):
+			log.debug("Plugin info file has no 'Core' section (in '%s')" % candidate_infofile)
+			return (None, None, None)
+		if not config_parser.has_option("Core","Name") or not config_parser.has_option("Core","Module"):
+			log.debug("Plugin info file has no 'Name' or 'Module' section (in '%s')" % candidate_infofile)
+			return (None, None, None)
+		# check that the given name is valid
+		name = config_parser.get("Core", "Name")
+		name = name.strip()
+		if PLUGIN_NAME_FORBIDEN_STRING in name:
+			log.debug("Plugin name contains forbiden character: %s (in '%s')" % (PLUGIN_NAME_FORBIDEN_STRING,
+																					candidate_infofile))
+			return (None, None, None)
+		return (name, config_parser.get("Core", "Module"), config_parser)
+	
+	def _extractCorePluginInfo(self,directory, filename):
+		"""
+		Gather the core information (name, and module to be loaded)
+		about a plugin described by it's info file (found at
+		'directory/filename').
+		
+		Return a dictionary with name and path of the plugin as well
+		as the ConfigParser instance used to collect these info.
+		
+		.. note:: This is supposed to be used internally by subclasses
+		          and decorators.
+		"""
+		# now we can consider the file as a serious candidate
+		if not isinstance(filename, _BASIC_STRING_CLASSES):
+			# filename is a file object: use it
+			name, moduleName, config_parser = self.getPluginNameAndModuleFromStream(filename)
+		else:
+			candidate_infofile_path = os.path.join(directory, filename)
+			# parse the information file to get info about the plugin
+			with open(candidate_infofile_path) as candidate_infofile:
+				name, moduleName, config_parser = self.getPluginNameAndModuleFromStream(candidate_infofile,candidate_infofile_path)
+		if (name, moduleName, config_parser) == (None, None, None):
+			return (None,None)
+		infos = {"name":name, "path":os.path.join(directory, moduleName)}
+		return infos, config_parser
+	
+	def _extractBasicPluginInfo(self,directory, filename):
+		"""
+		Gather some basic documentation about the plugin described by
+		it's info file (found at 'directory/filename').
+		
+		Return a dictionary containing the core information (name and
+		path) as well as as the 'documentation' info (version, author,
+		description etc).
+		
+		See also:
+		
+		  ``self._extractCorePluginInfo``
+		"""
+		infos, config_parser = self._extractCorePluginInfo(directory, filename)
+		# collect additional (but usually quite usefull) information
+		if infos and config_parser and config_parser.has_section("Documentation"):
+			if config_parser.has_option("Documentation","Author"):
+				infos["author"]	= config_parser.get("Documentation", "Author")
+			if config_parser.has_option("Documentation","Version"):
+				infos["version"] = config_parser.get("Documentation", "Version")
+			if config_parser.has_option("Documentation","Website"):
+				infos["website"] = config_parser.get("Documentation", "Website")
+			if config_parser.has_option("Documentation","Copyright"):
+				infos["copyright"]	= config_parser.get("Documentation", "Copyright")
+			if config_parser.has_option("Documentation","Description"):
+				infos["description"] = config_parser.get("Documentation", "Description")
+		return infos, config_parser
+		
+	def getInfosDictFromPlugin(self, dirpath, filename):
+		"""
+		Returns the extracted plugin informations as a dictionary.
+		This function ensures that "name" and "path" are provided.
+
+		If *callback* function has not been provided for this strategy,
+		we use the filename alone to extract minimal informations.
+		"""
+		infos, config_parser = self._extractBasicPluginInfo(dirpath, filename)
+		if not infos or infos.get("name", None) is None:
+			raise ValueError("Missing *name* of the plugin in extracted infos.")
+		if not infos or infos.get("path", None) is None:
+			raise ValueError("Missing *path* of the plugin in extracted infos.")
+		return infos, config_parser
+
+	
+class PluginFileAnalyzerMathingRegex(IPluginFileAnalyzer):
+	"""
+	An analyzer that targets plugins decribed by files whose name match a given regex.
+	"""
+	def __init__(self, name, regexp):
+		IPluginFileAnalyzer.__init__(self,name)
+		self.regexp = regexp
+	
+	def isValidPlugin(self, filename):
+		"""
+		Checks if the given filename is a valid plugin for this Strategy
+		"""
+		reg = re.compile(self.regexp)
+		if reg.match(filename) is not None:
+			return True
+		return False
+	
+	def getInfosDictFromPlugin(self, dirpath, filename):
+		"""
+		Returns the extracted plugin informations as a dictionary.
+		This function ensures that "name" and "path" are provided.
+		"""
+		# use the filename alone to extract minimal informations.
+		infos = {}
+		module_name = os.path.splitext(filename)[0]
+		plugin_filename = os.path.join(dirpath,filename)
+		if module_name == "__init__":
+			module_name = os.path.basename(dirpath)
+			plugin_filename = dirpath
+		infos["name"] = "%s" % module_name
+		infos["path"] = plugin_filename
+		cf_parser = ConfigParser()
+		cf_parser.add_section("Core")
+		cf_parser.set("Core","Name",infos["name"])
+		cf_parser.set("Core","Module",infos["path"])
+		return infos,cf_parser
+
+
+
+class PluginFileLocator(IPluginLocator):
+	"""
+	Locates plugins on the file system using a set of analyzers to
+	determine what files actually corresponds to plugins.
+	
+	If more than one analyzer is being used, the first that will discover a
+	new plugin will avoid other strategies to find it too.
+
+	By default each directory set as a "plugin place" is scanned
+	recursively. You can change that by a call to
+	``disableRecursiveScan``.
+	"""
+	
+	def __init__(self, analyzers=None, plugin_info_cls=PluginInfo):
+		IPluginLocator.__init__(self)
+		self._discovered_plugins = {}
+		self.setPluginPlaces(None)
+		self._analyzers = analyzers      # analyzers used to locate plugins
+		if self._analyzers is None:
+			self._analyzers = [PluginFileAnalyzerWithInfoFile("info_ext")]
+		self._default_plugin_info_cls = plugin_info_cls
+		self._plugin_info_cls_map = {}
+		self._max_size = 1e3*1024 # in octets (by default 1 Mo)
+		self.recursive = True
+		
+	def disableRecursiveScan(self):
+		"""
+		Disable recursive scan of the directories given as plugin places.
+		"""
+		self.recursive = False		
+	
+	def setAnalyzers(self, analyzers):
+		"""
+		Sets a new set of analyzers.
+
+		.. warning:: the new analyzers won't be aware of the plugin
+		             info class that may have been set via a previous
+		             call to ``setPluginInfoClass``.
+		"""
+		self._analyzers = analyzers
+
+	def removeAnalyzers(self, name):
+		"""
+		Removes analyzers of a given name.
+		"""
+		analyzersListCopy = self._analyzers[:]
+		foundAndRemoved = False
+		for obj in analyzersListCopy:
+			if obj.name == name:
+				self._analyzers.remove(obj)
+				foundAndRemoved = True
+		if not foundAndRemoved:
+			log.debug("'%s' is not a known strategy name: can't remove it." % name)
+
+	def removeAllAnalyzer(self):
+		"""
+		Remove all analyzers.
+		"""
+		self._analyzers = []
+	
+	def appendAnalyzer(self, analyzer):
+		"""
+		Append an analyzer to the existing list.
+		"""
+		self._analyzers.append(analyzer)
+
+
+	def _getInfoForPluginFromAnalyzer(self,analyzer,dirpath, filename):
+		"""
+		Return an instance of plugin_info_cls filled with data extracted by the analyzer.
+
+		May return None if the analyzer fails to extract any info.
+		"""
+		plugin_info_dict,config_parser = analyzer.getInfosDictFromPlugin(dirpath, filename)
+		if plugin_info_dict is None:
+			return None
+		plugin_info_cls = self._plugin_info_cls_map.get(analyzer.name,self._default_plugin_info_cls)
+		plugin_info = plugin_info_cls(plugin_info_dict["name"],plugin_info_dict["path"])
+		plugin_info.details = config_parser
+		return plugin_info
+	
+	def locatePlugins(self):
+		"""
+		Walk through the plugins' places and look for plugins.
+
+		Return the candidates and number of plugins found.
+		"""
+# 		print "%s.locatePlugins" % self.__class__
+		_candidates = []
+		_discovered = {}
+		for directory in map(os.path.abspath, self.plugins_places):
+			# first of all, is it a directory :)
+			if not os.path.isdir(directory):
+				log.debug("%s skips %s (not a directory)" % (self.__class__.__name__, directory))
+				continue
+			if self.recursive:
+				debug_txt_mode = "recursively"
+				walk_iter = os.walk(directory, followlinks=True)
+			else:
+				debug_txt_mode = "non-recursively"
+				walk_iter = [(directory,[],os.listdir(directory))]
+			# iteratively walks through the directory
+			log.debug("%s walks (%s) into directory: %s" % (self.__class__.__name__, debug_txt_mode, directory))
+			for item in walk_iter:
+				dirpath = item[0]
+				for filename in item[2]:
+					# print("testing candidate file %s" % filename)
+					for analyzer in self._analyzers:
+						# print("... with analyzer %s" % analyzer.name)
+						# eliminate the obvious non plugin files
+						if not analyzer.isValidPlugin(filename):
+							log.debug("%s is not a valid plugin for strategy %s" % (filename, analyzer.name))
+							continue
+						candidate_infofile = os.path.join(dirpath, filename)
+						if candidate_infofile in _discovered:
+							log.debug("%s (with strategy %s) rejected because already discovered" % (candidate_infofile, analyzer.name))
+							continue
+						log.debug("%s found a candidate:\n    %s" % (self.__class__.__name__, candidate_infofile))
+#						print candidate_infofile
+						plugin_info = self._getInfoForPluginFromAnalyzer(analyzer, dirpath, filename)
+						if plugin_info is None:
+							log.debug("Plugin candidate '%s'  rejected by strategy '%s'" % (candidate_infofile, analyzer.name))
+							break # we consider this was the good strategy to use for: it failed -> not a plugin -> don't try another strategy
+						# now determine the path of the file to execute,
+						# depending on wether the path indicated is a
+						# directory or a file
+#					print plugin_info.path
+						# Remember all the files belonging to a discovered
+						# plugin, so that strategies (if several in use) won't
+						# collide
+						if os.path.isdir(plugin_info.path):
+							candidate_filepath = os.path.join(plugin_info.path, "__init__")
+							# it is a package, adds all the files concerned
+							for _file in os.listdir(plugin_info.path):
+								if _file.endswith(".py"):
+									self._discovered_plugins[os.path.join(plugin_info.path, _file)] = candidate_filepath
+									_discovered[os.path.join(plugin_info.path, _file)] = candidate_filepath
+						elif (plugin_info.path.endswith(".py") and os.path.isfile(plugin_info.path)) or os.path.isfile(plugin_info.path+".py"):
+							candidate_filepath = plugin_info.path
+							if candidate_filepath.endswith(".py"):
+								candidate_filepath = candidate_filepath[:-3]
+							# it is a file, adds it
+							self._discovered_plugins[".".join((plugin_info.path, "py"))] = candidate_filepath
+							_discovered[".".join((plugin_info.path, "py"))] = candidate_filepath
+						else:
+							log.error("Plugin candidate rejected: cannot find the file or directory module for '%s'" % (candidate_infofile))
+							break
+#					print candidate_filepath
+						_candidates.append((candidate_infofile, candidate_filepath, plugin_info))
+						# finally the candidate_infofile must not be discovered again
+						_discovered[candidate_infofile] = candidate_filepath
+						self._discovered_plugins[candidate_infofile] = candidate_filepath
+#						print "%s found by strategy %s" % (candidate_filepath, analyzer.name)
+		return _candidates, len(_candidates)
+
+	def gatherCorePluginInfo(self, directory, filename):
+		"""
+		Return a ``PluginInfo`` as well as the ``ConfigParser`` used to build it.
+		
+		If filename is a valid plugin discovered by any of the known
+		strategy in use. Returns None,None otherwise.
+		"""
+		for analyzer in self._analyzers:
+			# eliminate the obvious non plugin files
+			if not analyzer.isValidPlugin(filename):
+				continue
+			plugin_info = self._getInfoForPluginFromAnalyzer(analyzer,directory, filename)
+			return plugin_info,plugin_info.details
+		return None,None
+	
+	# -----------------------------------------------
+	# Backward compatible methods
+	# Note: their implementation must be conform to their
+	# counterpart in yapsy<1.10
+	# -----------------------------------------------
+
+	def getPluginNameAndModuleFromStream(self, infoFileObject, candidate_infofile=None):
+		for analyzer in self._analyzers:
+			if analyzer.name == "info_ext":
+				return analyzer.getPluginNameAndModuleFromStream(infoFileObject)
+		else:
+			raise RuntimeError("No current file analyzer is able to provide plugin information from stream")
+	
+	def setPluginInfoClass(self, picls, name=None):
+		"""
+		Set the class that holds PluginInfo. The class should inherit
+		from ``PluginInfo``.
+
+		If name is given, then the class will be used only by the corresponding analyzer.
+		
+		If name is None, the class will be set for all analyzers.
+		"""
+		if name is None:
+			self._default_plugin_info_cls = picls
+			self._plugin_info_cls_map = {}
+		else:
+			self._plugin_info_cls_map[name] = picls
+			
+	def setPluginPlaces(self, directories_list):
+		"""
+		Set the list of directories where to look for plugin places.
+		"""
+		if isinstance(directories_list, _BASIC_STRING_CLASSES):
+			raise ValueError("'directories_list' given as a string, but expected to be a list or enumeration of strings")
+		if directories_list is None:
+			directories_list = [os.path.dirname(__file__)]
+		self.plugins_places = directories_list
+
+	def updatePluginPlaces(self, directories_list):
+		"""
+		Updates the list of directories where to look for plugin places.
+		"""
+		self.plugins_places = list(set.union(set(directories_list), set(self.plugins_places)))
+
+	def setPluginInfoExtension(self, ext):
+		"""
+		DEPRECATED(>1.9): for backward compatibility. Directly configure the
+		IPluginLocator instance instead !
+
+		This will only work if the strategy "info_ext" is active
+		for locating plugins.
+		"""
+		for analyzer in self._analyzers:
+			if analyzer.name == "info_ext":
+				analyzer.setPluginInfoExtension(ext)

--- a/src/yapsy/PluginInfo.py
+++ b/src/yapsy/PluginInfo.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+Encapsulate a plugin instance as well as some metadata.
+
+API
+===
+"""
+
+from yapsy.compat import ConfigParser
+try:
+	from distutils.version import StrictVersion
+except ImportError:
+	from packaging.version import Version as StrictVersion
+
+
+class PluginInfo(object):
+	"""Representation of the most basic set of information related to a
+	given plugin such as its name, author, description...
+
+	Any additional information can be stored ad retrieved in a
+	PluginInfo, when this one is created with a
+	``ConfigParser.ConfigParser`` instance.
+
+	This typically means that when metadata is read from a text file
+	(the original way for yapsy to describe plugins), all info that is
+	not part of the basic variables (name, path, version etc), can
+	still be accessed though the ``details`` member variables that
+	behaves like Python's ``ConfigParser.ConfigParser``.
+
+	.. warning:: 
+	    The instance associated with the ``details`` member
+		variable is never copied and used to store all plugin infos. If
+		you set it to a custom instance, it will be modified as soon as
+		another member variale of the plugin info is
+		changed. Alternatively, if you change the instance "outside" the
+		plugin info, it will also change the plugin info.
+		
+	Ctor Arguments:
+
+	:plugin_name: is  a simple string describing the name of
+	              the plugin.
+
+	:plugin_path: describe the location where the plugin can be
+                  found.
+		
+	.. warning:: 
+	    The ``path`` attribute is the full path to the
+		plugin if it is organised as a directory or the
+		full path to a file without the ``.py`` extension
+		if the plugin is defined by a simple file. In the
+		later case, the actual plugin is reached via
+		``plugin_info.path+'.py'``.
+	"""
+	
+	def __init__(self, plugin_name, plugin_path):
+		self.__details = ConfigParser()
+		self.name = plugin_name
+		self.path = plugin_path
+		self._ensureDetailsDefaultsAreBackwardCompatible()
+		# Storage for stuff created during the plugin lifetime
+		self.plugin_object = None
+		self.categories    = []
+		self.error = None
+
+
+	def __setDetails(self,cfDetails):
+		"""
+		Fill in all details by storing a ``ConfigParser`` instance.
+
+		.. warning:: 
+		    The values for ``plugin_name`` and
+			``plugin_path`` given a init time will superseed
+			any value found in ``cfDetails`` in section
+			'Core' for the options 'Name' and 'Module' (this
+			is mostly for backward compatibility).
+		"""	
+		bkp_name = self.name
+		bkp_path = self.path
+		self.__details = cfDetails
+		self.name = bkp_name
+		self.path = bkp_path
+		self._ensureDetailsDefaultsAreBackwardCompatible()
+	
+	def __getDetails(self):
+		return self.__details
+		
+	def __getName(self):
+		return self.details.get("Core","Name")
+	
+	def __setName(self, name):
+		if not self.details.has_section("Core"):
+			self.details.add_section("Core")
+		self.details.set("Core","Name",name)
+
+	
+	def __getPath(self):
+		return self.details.get("Core","Module")
+	
+	def __setPath(self,path):
+		if not self.details.has_section("Core"):
+			self.details.add_section("Core")
+		self.details.set("Core","Module",path)
+
+	
+	def __getVersion(self):
+		return StrictVersion(self.details.get("Documentation","Version"))
+	
+	def setVersion(self, vstring):
+		"""
+		Set the version of the plugin.
+
+		Used by subclasses to provide different handling of the
+		version number.
+		"""
+		if isinstance(vstring,StrictVersion):
+			vstring = str(vstring)
+		if not self.details.has_section("Documentation"):
+			self.details.add_section("Documentation")
+		self.details.set("Documentation","Version",vstring)
+
+	def __getAuthor(self):
+		return self.details.get("Documentation","Author")
+		
+	def __setAuthor(self,author):
+		if not self.details.has_section("Documentation"):
+			self.details.add_section("Documentation")
+		self.details.set("Documentation","Author",author)
+
+
+	def __getCopyright(self):
+		return self.details.get("Documentation","Copyright")
+		
+	def __setCopyright(self,copyrightTxt):
+		if not self.details.has_section("Documentation"):
+			self.details.add_section("Documentation")
+		self.details.set("Documentation","Copyright",copyrightTxt)
+
+	
+	def __getWebsite(self):
+		return self.details.get("Documentation","Website")
+		
+	def __setWebsite(self,website):
+		if not self.details.has_section("Documentation"):
+			self.details.add_section("Documentation")
+		self.details.set("Documentation","Website",website)
+
+	
+	def __getDescription(self):
+		return self.details.get("Documentation","Description")
+	
+	def __setDescription(self,description):
+		if not self.details.has_section("Documentation"):
+			self.details.add_section("Documentation")
+		return self.details.set("Documentation","Description",description)
+
+
+	def __getCategory(self):
+		"""
+		DEPRECATED (>1.9): Mimic former behaviour when what is
+		noz the first category was considered as the only one the
+		plugin belonged to.
+		"""		
+		if self.categories:
+			return self.categories[0]
+		else:
+			return "UnknownCategory"
+	
+	def __setCategory(self,c):
+		"""
+		DEPRECATED (>1.9): Mimic former behaviour by making so
+		that if a category is set as if it were the only category to
+		which the plugin belongs, then a __getCategory will return
+		this newly set category.
+		"""
+		self.categories = [c] + self.categories
+	
+	name = property(fget=__getName,fset=__setName)
+	path = property(fget=__getPath,fset=__setPath)
+	version = property(fget=__getVersion,fset=setVersion)
+	author = property(fget=__getAuthor,fset=__setAuthor)
+	copyright = property(fget=__getCopyright,fset=__setCopyright)
+	website = property(fget=__getWebsite,fset=__setWebsite)
+	description = property(fget=__getDescription,fset=__setDescription)
+	details = property(fget=__getDetails,fset=__setDetails)
+	# deprecated (>1.9): plugins are not longer associated to a
+	# single category !
+	category = property(fget=__getCategory,fset=__setCategory)
+	
+	def _getIsActivated(self):
+		"""
+		Return the activated state of the plugin object.
+		Makes it possible to define a property.
+		"""
+		return self.plugin_object.is_activated
+	
+	is_activated = property(fget=_getIsActivated)
+	
+	def _ensureDetailsDefaultsAreBackwardCompatible(self):
+		"""
+		Internal helper function.
+		"""
+		if not self.details.has_option("Documentation","Author"):
+			self.author		= "Unknown"
+		if not self.details.has_option("Documentation","Version"):
+			self.version	= "0.0"
+		if not self.details.has_option("Documentation","Website"):
+			self.website	= "None"
+		if not self.details.has_option("Documentation","Copyright"):
+			self.copyright	= "Unknown"
+		if not self.details.has_option("Documentation","Description"):
+			self.description = ""

--- a/src/yapsy/PluginManager.py
+++ b/src/yapsy/PluginManager.py
@@ -1,0 +1,742 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+The ``PluginManager`` loads plugins that enforce the `Plugin
+Description Policy`_, and offers the most simple methods to activate
+and deactivate the plugins once they are loaded.
+
+.. note:: It may also classify the plugins in various categories, but
+          this behaviour is optional and if not specified elseway all
+          plugins are stored in the same default category.
+
+.. note:: It is often more useful to have the plugin manager behave
+          like singleton, this functionality is provided by
+          ``PluginManagerSingleton``
+
+
+Plugin Description Policy
+=========================
+
+When creating a ``PluginManager`` instance, one should provide it with
+a list of directories where plugins may be found. In each directory,
+a plugin should contain the following elements:
+
+For a  *Standard* plugin:
+
+  ``myplugin.yapsy-plugin`` 
+ 
+      A *plugin info file* identical to the one previously described.
+ 
+  ``myplugin``
+ 
+      A directory ontaining an actual Python plugin (ie with a
+      ``__init__.py`` file that makes it importable). The upper
+      namespace of the plugin should present a class inheriting the
+      ``IPlugin`` interface (the same remarks apply here as in the
+      previous case).
+
+
+For a *Single file* plugin:
+
+  ``myplugin.yapsy-plugin`` 
+       
+      A *plugin info file* which is identified thanks to its extension,
+      see the `Plugin Info File Format`_ to see what should be in this
+      file.
+   
+      The extension is customisable at the ``PluginManager``'s
+      instanciation, since one may usually prefer the extension to bear
+      the application name.
+  
+  ``myplugin.py``
+  
+      The source of the plugin. This file should at least define a class
+      inheriting the ``IPlugin`` interface. This class will be
+      instanciated at plugin loading and it will be notified the
+      activation/deactivation events.
+
+
+Plugin Info File Format
+-----------------------
+
+The plugin info file is a text file *encoded in ASCII or UTF-8* and
+gathering, as its name suggests, some basic information about the
+plugin.
+
+- it gives crucial information needed to be able to load the plugin
+
+- it provides some documentation like information like the plugin
+  author's name and a short description fo the plugin functionality.
+
+Here is an example of what such a file should contain::
+
+      [Core]
+      Name = My plugin Name
+      Module = the_name_of_the_pluginto_load_with_no_py_ending
+         
+      [Documentation]
+      Description = What my plugin broadly does
+      Author = My very own name
+      Version = the_version_number_of_the_plugin
+      Website = My very own website
+      
+      
+ 
+.. note:: From such plugin descriptions, the ``PluginManager`` will
+          built its own representations of the plugins as instances of
+          the :doc:`PluginInfo` class.
+
+Changing the default behaviour
+==============================
+
+The default behaviour for locating and loading plugins can be changed
+using the various options exposed on the interface via getters.
+
+The plugin detection, in particular, can be fully customized by
+settting a custom plugin locator. See ``IPluginLocator`` for more
+details on this.
+
+
+Extensibility
+=============
+
+Several mechanisms have been put up to help extending the basic
+functionalities of the proivided classes.
+
+A few *hints* to help you extend those classes:
+
+If the new functionalities do not overlap the ones already
+implemented, then they should be implemented as a Decorator class of the
+base plugin. This should be done by inheriting the
+``PluginManagerDecorator``.
+
+If this previous way is not possible, then the functionalities should
+be added as a subclass of ``PluginManager``.
+
+.. note:: The first method is highly prefered since it makes it
+          possible to have a more flexible design where one can pick
+          several functionalities and litterally *add* them to get an
+          object corresponding to one's precise needs.
+
+API
+===
+ 
+"""
+
+import sys
+import os
+import importlib
+
+from yapsy import log
+from yapsy import NormalizePluginNameForModuleName
+
+from yapsy.IPlugin import IPlugin
+from yapsy.IPluginLocator import IPluginLocator
+# The follozing two imports are used to implement the default behaviour
+from yapsy.PluginFileLocator import PluginFileAnalyzerWithInfoFile
+from yapsy.PluginFileLocator import PluginFileLocator
+# imported for backward compatibility (this variable was defined here
+# before 1.10)
+from yapsy import PLUGIN_NAME_FORBIDEN_STRING
+# imported for backward compatibility (this PluginInfo was imported
+# here before 1.10)
+from yapsy.PluginInfo import PluginInfo
+
+
+class PluginManager(object):
+	"""
+	Manage several plugins by ordering them in categories.
+	
+	The mechanism for searching and loading the plugins is already
+	implemented in this class so that it can be used directly (hence
+	it can be considered as a bit more than a mere interface)
+	
+	The file describing a plugin must be written in the syntax
+	compatible with Python's ConfigParser module as in the
+	`Plugin Info File Format`_
+
+	About the __init__:
+
+	Initialize the mapping of the categories and set the list of
+	directories where plugins may be. This can also be set by
+	direct call the methods: 
+		
+	- ``setCategoriesFilter`` for ``categories_filter``
+	- ``setPluginPlaces`` for ``directories_list``
+	- ``setPluginInfoExtension`` for ``plugin_info_ext``
+
+	You may look at these function's documentation for the meaning
+	of each corresponding arguments.
+	"""
+
+	def __init__(self,
+				 categories_filter=None,
+				 directories_list=None,
+				 plugin_info_ext=None,
+				 plugin_locator=None):
+		# as a good practice we don't use mutable objects as default
+		# values (these objects would become like static variables)
+		# for function/method arguments, but rather use None.
+		if categories_filter is None:
+			categories_filter = {"Default":IPlugin}
+		self.setCategoriesFilter(categories_filter)
+		plugin_locator = self._locatorDecide(plugin_info_ext, plugin_locator)
+		# plugin_locator could be either a dict defining strategies, or directly
+		# an IPluginLocator object
+		self.setPluginLocator(plugin_locator, directories_list)
+
+	def _locatorDecide(self, plugin_info_ext, plugin_locator):
+		"""
+		For backward compatibility, we kept the *plugin_info_ext* argument.
+		Thus we may use it if provided. Returns the (possibly modified)
+		*plugin_locator*.
+		"""
+		specific_info_ext = plugin_info_ext is not None
+		specific_locator = plugin_locator is not None
+		if not specific_info_ext and not specific_locator:
+			# use the default behavior
+			res = PluginFileLocator()
+		elif not specific_info_ext and specific_locator:
+			# plugin_info_ext not used
+			res = plugin_locator
+		elif not specific_locator and specific_info_ext:
+			# plugin_locator not used, and plugin_info_ext provided
+			# -> compatibility mode
+			res = PluginFileLocator()
+			res.setAnalyzers([PluginFileAnalyzerWithInfoFile("info_ext",plugin_info_ext)])
+		elif specific_info_ext and specific_locator:
+			# both provided... issue a warning that tells "plugin_info_ext"
+			# will be ignored
+			msg = ("Two incompatible arguments (%s) provided:",
+				   "'plugin_info_ext' and 'plugin_locator'). Ignoring",
+				   "'plugin_info_ext'.")
+			raise ValueError(" ".join(msg) % self.__class__.__name__)
+		return res
+	
+	def setCategoriesFilter(self, categories_filter):
+		"""
+		Set the categories of plugins to be looked for as well as the
+		way to recognise them.
+		
+		The ``categories_filter`` first defines the various categories
+		in which the plugins will be stored via its keys and it also
+		defines the interface tha has to be inherited by the actual
+		plugin class belonging to each category.
+		"""
+		self.categories_interfaces = categories_filter.copy()
+		# prepare the mapping from categories to plugin lists
+		self.category_mapping = {}
+		# also maps the plugin info files (useful to avoid loading
+		# twice the same plugin...)
+		self._category_file_mapping = {}
+		for categ in categories_filter:
+			self.category_mapping[categ] = []
+			self._category_file_mapping[categ] = []
+			
+
+	def setPluginPlaces(self, directories_list):
+		"""
+		DEPRECATED(>1.9): directly configure the IPluginLocator instance instead !
+		
+		Convenience method (actually call the IPluginLocator method)
+		"""
+		self.getPluginLocator().setPluginPlaces(directories_list)
+
+	def updatePluginPlaces(self, directories_list):
+		"""
+		DEPRECATED(>1.9): directly configure the IPluginLocator instance instead !
+
+		Convenience method (actually call the IPluginLocator method)
+		"""
+		self.getPluginLocator().updatePluginPlaces(directories_list)
+
+	def setPluginInfoExtension(self, ext):
+		"""
+		DEPRECATED(>1.9): for backward compatibility. Directly configure the
+		IPluginLocator instance instead !
+		
+		.. warning:: This will only work if the strategy "info_ext" is
+		             active for locating plugins.
+		"""
+		try:
+			self.getPluginLocator().setPluginInfoExtension(ext)
+		except KeyError:
+			log.error("Current plugin locator doesn't support setting the plugin info extension.")
+
+	def setPluginInfoClass(self, picls, strategies=None):
+		"""
+		DEPRECATED(>1.9): directly configure the IPluginLocator instance instead !
+		
+		Convenience method (actually call self.getPluginLocator().setPluginInfoClass)
+		
+		When using a ``PluginFileLocator`` you may restrict the
+		strategies to which the change of PluginInfo class will occur
+		by just giving the list of strategy names in the argument
+		"strategies"
+		"""
+		if strategies:
+			for name in strategies:
+				self.getPluginLocator().setPluginInfoClass(picls, name)
+		else:
+			self.getPluginLocator().setPluginInfoClass(picls)
+
+	def getPluginInfoClass(self):
+		"""
+		DEPRECATED(>1.9): directly control that with the IPluginLocator
+		instance instead !
+		
+		Get the class that holds PluginInfo.
+		"""
+		return self.getPluginLocator().getPluginInfoClass()
+
+	def setPluginLocator(self, plugin_locator, dir_list=None, picls=None):
+		"""
+		Sets the strategy used to locate the basic information.
+
+		.. note: 
+		    If a `dir_list` is provided it overrides the directory list
+		    that may have been previously set in the locator.
+
+		See :doc:`IPluginLocator` for the policy that `plugin_locator` must enforce.
+		"""
+		if isinstance(plugin_locator, IPluginLocator):
+			self._plugin_locator = plugin_locator
+			if dir_list is not None:
+				self._plugin_locator.setPluginPlaces(dir_list)
+			if picls is not None:
+				self.setPluginInfoClass(picls)
+		else:
+			raise TypeError("Unexpected format for plugin_locator ('%s' is not an instance of IPluginLocator)" % plugin_locator)
+		
+	def getPluginLocator(self):
+		"""
+		Grant direct access to the plugin locator.
+		"""
+		return self._plugin_locator
+	
+	def _gatherCorePluginInfo(self, directory, plugin_info_filename):
+		"""
+		DEPRECATED(>1.9): please use a specific plugin
+		locator if you need such information.
+
+		Gather the core information (name, and module to be loaded)
+		about a plugin described by it's info file (found at
+		'directory/filename').
+		
+		Return an instance of ``PluginInfo`` and the
+		config_parser used to gather the core data *in a tuple*, if the
+		required info could be localised, else return ``(None,None)``.
+
+		.. note:: This is supposed to be used internally by subclasses
+		and decorators.
+
+		"""
+		return self.getPluginLocator().gatherCorePluginInfo(directory,plugin_info_filename)
+
+	def _getPluginNameAndModuleFromStream(self,infoFileObject,candidate_infofile="<buffered info>"):
+		"""
+		DEPRECATED(>1.9): please use a specific plugin
+		locator if you need such information.
+		
+		Extract the name and module of a plugin from the
+		content of the info file that describes it and which
+		is stored in infoFileObject.
+		
+		.. note:: 
+		    Prefer using ``_gatherCorePluginInfo``
+		    instead, whenever possible...
+		
+		.. warning:: 
+		    ``infoFileObject`` must be a file-like
+		    object: either an opened file for instance or a string
+			buffer wrapped in a StringIO instance as another
+			example.
+
+		.. note:: 
+		    ``candidate_infofile`` must be provided
+			whenever possible to get better error messages.
+			
+		Return a 3-uple with the name of the plugin, its
+		module and the config_parser used to gather the core
+		data *in a tuple*, if the required info could be
+		localised, else return ``(None,None,None)``.
+
+		.. note:: 
+		    This is supposed to be used internally by subclasses
+			and decorators.
+		"""
+		return self.getPluginLocator().getPluginNameAndModuleFromStream(infoFileObject, candidate_infofile)
+	
+	
+	def getCategories(self):
+		"""
+		Return the list of all categories.
+		"""
+		return list(self.category_mapping.keys())
+
+	def removePluginFromCategory(self, plugin,category_name):
+		"""
+		Remove a plugin from the category where it's assumed to belong.
+		"""
+		self.category_mapping[category_name].remove(plugin)
+
+
+	def appendPluginToCategory(self, plugin, category_name):
+		"""
+		Append a new plugin to the given category.
+		"""
+		self.category_mapping[category_name].append(plugin)
+		
+	def getPluginsOfCategory(self, category_name):
+		"""
+		Return the list of all plugins belonging to a category.
+		"""
+		return self.category_mapping[category_name][:]
+
+	def getAllPlugins(self):
+		"""
+		Return the list of all plugins (belonging to all categories).
+		"""
+		allPlugins = set()
+		for pluginsOfOneCategory in self.category_mapping.values():
+				allPlugins.update(pluginsOfOneCategory)
+		return list(allPlugins)
+
+	def getPluginsOf(self, **kwargs):
+		"""
+		Returns a set of plugins whose properties match the named arguments provided here along with their correspoding values.
+		"""
+		selectedPLugins = set()
+		for plugin in self.getAllPlugins():
+			for attrName in kwargs:
+				if not hasattr(plugin, attrName):
+					break
+				attrValue = kwargs[attrName]
+				pluginValue = getattr(plugin, attrName)
+				if pluginValue == attrValue:
+					continue
+				if type(pluginValue) == type(attrValue):
+					break
+				try:
+					if attrValue in pluginValue:
+						continue
+				except:
+					break
+			else:
+				selectedPLugins.add(plugin)
+		return selectedPLugins
+	
+	def getPluginCandidates(self):
+		"""
+		Return the list of possible plugins.
+
+		Each possible plugin (ie a candidate) is described by a 3-uple:
+		(info file path, python file path, plugin info instance)
+
+		.. warning: ``locatePlugins`` must be called before !
+		"""
+		if not hasattr(self, '_candidates'):
+			raise RuntimeError("locatePlugins must be called before getPluginCandidates")
+		return self._candidates[:]
+
+	def removePluginCandidate(self,candidateTuple):
+		"""
+		Remove a given candidate from the list of plugins that should be loaded.
+
+		The candidate must be represented by the same tuple described
+		in ``getPluginCandidates``.
+
+		.. warning: ``locatePlugins`` must be called before !
+		"""
+		if not hasattr(self, '_candidates'):
+			raise ValueError("locatePlugins must be called before removePluginCandidate")
+		self._candidates.remove(candidateTuple)
+
+	def appendPluginCandidate(self, candidateTuple):
+		"""
+		Append a new candidate to the list of plugins that should be loaded.
+
+		The candidate must be represented by the same tuple described
+		in ``getPluginCandidates``.
+
+		.. warning: ``locatePlugins`` must be called before !
+		"""
+		if not hasattr(self, '_candidates'):
+			raise ValueError("locatePlugins must be called before removePluginCandidate")
+		self._candidates.append(candidateTuple)
+
+	def locatePlugins(self):
+		"""
+		Convenience method (actually call the IPluginLocator method)
+		"""
+		self._candidates, npc = self.getPluginLocator().locatePlugins()
+	
+	def loadPlugins(self, callback=None, callback_after=None):
+		"""
+		Load the candidate plugins that have been identified through a
+		previous call to locatePlugins.  For each plugin candidate
+		look for its category, load it and store it in the appropriate
+		slot of the ``category_mapping``.
+
+		You can specify 2 callbacks: callback, and callback_after. If either of these are passed a function, (in the case of callback), it will get called before each plugin load attempt and (for callback_after), after each 
+		attempt.  The ``plugin_info`` instance is passed as an argument to
+		each callback. This is meant to facilitate code that needs to run for each plugin, such as adding the directory it resides in to sys.path (so imports of other files in the plugin's directory work correctly). You can use callback_after to remove anything you added to the path.
+		"""
+# 		print "%s.loadPlugins" % self.__class__
+		if not hasattr(self, '_candidates'):
+			raise ValueError("locatePlugins must be called before loadPlugins")
+
+		processed_plugins = []
+		for candidate_infofile, candidate_filepath, plugin_info in self._candidates:
+			# make sure to attribute a unique module name to the one
+			# that is about to be loaded
+			plugin_module_name_template = NormalizePluginNameForModuleName("yapsy_loaded_plugin_" + plugin_info.name) + "_%d"
+			for plugin_name_suffix in range(len(sys.modules)):
+				plugin_module_name =  plugin_module_name_template % plugin_name_suffix
+				if plugin_module_name not in sys.modules:
+					break
+			
+			# tolerance on the presence (or not) of the py extensions
+			if candidate_filepath.endswith(".py"):
+				candidate_filepath = candidate_filepath[:-3]
+			# if a callback exists, call it before attempting to load
+			# the plugin so that a message can be displayed to the
+			# user
+			if callback is not None:
+				callback(plugin_info)
+			# cover the case when the __init__ of a package has been
+			# explicitely indicated
+			if "__init__" in  os.path.basename(candidate_filepath):
+				candidate_filepath = os.path.dirname(candidate_filepath)
+			try:
+				candidate_module = PluginManager._importModule(plugin_module_name, candidate_filepath)
+			except Exception:
+				exc_info = sys.exc_info()
+				log.error("Unable to import plugin: %s" % candidate_filepath, exc_info=exc_info)
+				plugin_info.error = exc_info
+				processed_plugins.append(plugin_info)
+				continue
+
+			processed_plugins.append(plugin_info)
+			if "__init__" in  os.path.basename(candidate_filepath):
+				sys.path.remove(plugin_info.path)
+			# now try to find and initialise the first subclass of the correct plugin interface
+			last_failed_attempt_message = None
+			for element, element_name in ((getattr(candidate_module,name),name) for name in dir(candidate_module)):
+				plugin_info_reference = None
+				for category_name in self.categories_interfaces:
+					try:
+						is_correct_subclass = issubclass(element, self.categories_interfaces[category_name])
+					except Exception:
+						exc_info = sys.exc_info()
+						log.debug("correct subclass tests failed for: %s in %s" % (element_name, candidate_filepath), exc_info=exc_info)
+						continue
+					if is_correct_subclass and element is not self.categories_interfaces[category_name]:
+							current_category = category_name
+							if candidate_infofile not in self._category_file_mapping[current_category]:
+								# we found a new plugin: initialise it and search for the next one
+								if not plugin_info_reference:
+									try:
+										plugin_info.plugin_object = self.instanciateElementWithImportInfo(element, element_name, plugin_module_name, candidate_filepath)
+										plugin_info_reference = plugin_info
+									except Exception:
+										exc_info = sys.exc_info()
+										last_failed_attempt_message = "Unable to create plugin object: %s" % candidate_filepath
+										log.debug(last_failed_attempt_message, exc_info=exc_info)
+										plugin_info.error = exc_info
+										break # If it didn't work once it wont again
+									else:
+										last_failed_attempt_message = None
+								plugin_info.categories.append(current_category)
+								self.category_mapping[current_category].append(plugin_info_reference)
+								self._category_file_mapping[current_category].append(candidate_infofile)
+								#Everything is loaded and instantiated for this plugin now
+								if callback_after is not None:
+									callback_after(plugin_info)
+			else:
+				if last_failed_attempt_message:
+					log.error(last_failed_attempt_message, exc_info=plugin_info.error)
+					
+		# Remove candidates list since we don't need them any more and
+		# don't need to take up the space
+		delattr(self, '_candidates')
+		return processed_plugins
+
+	
+	@staticmethod
+	def _importModule(plugin_module_name, candidate_filepath):
+		"""
+		Import a module, trying either to find it as a single file or as a directory.
+
+		.. note:: Isolated and provided to be reused, but not to be reimplemented !
+		"""
+		# use imp to correctly load the plugin as a module
+		candidate_module = None
+		filepath_base = candidate_filepath.split('/')[-1]
+		if os.path.isdir(candidate_filepath):
+			location = candidate_filepath + '/__init__.py'
+		else:
+			location = candidate_filepath + '.py'
+		spec = importlib.util.spec_from_file_location(filepath_base, location)
+		if (spec):
+			candidate_module = importlib.util.module_from_spec(spec)
+			sys.modules[plugin_module_name] = candidate_module
+			spec.loader.exec_module(candidate_module)
+		return candidate_module
+	
+	def instanciateElementWithImportInfo(self, element, element_name,
+										 plugin_module_name, candidate_filepath):
+		"""Override this method to customize how plugins are instanciated.
+		
+		.. note:: 
+		    This methods recieves the 'element' that is a candidate
+		    as the plugin's main file, but also enough information to reload
+		    its containing module and this element.
+		"""
+		return self.instanciateElement(element)
+	
+	def instanciateElement(self, element):
+		"""
+		DEPRECATED(>1.11): reimplement instead ``instanciateElementWithImportInfo`` !
+		
+		Override this method to customize how plugins are instanciated.
+
+		.. warning::
+		    This method is called only if
+		    ``instanciateElementWithImportInfo`` has not been reimplemented !
+		"""
+		return element()
+	
+	def collectPlugins(self):
+		"""
+		Walk through the plugins' places and look for plugins.  Then
+		for each plugin candidate look for its category, load it and
+		stores it in the appropriate slot of the category_mapping.
+		"""
+# 		print "%s.collectPlugins" % self.__class__		
+		self.locatePlugins()
+		self.loadPlugins()
+
+
+	def getPluginByName(self,name,category="Default"):
+		"""
+		Get the plugin correspoding to a given category and name
+		"""
+		if category in self.category_mapping:
+			for item in self.category_mapping[category]:
+				if item.name == name:
+					return item
+		return None
+
+	def activatePluginByName(self,name,category="Default"):
+		"""
+		Activate a plugin corresponding to a given category + name.
+		"""
+		pta_item = self.getPluginByName(name,category)
+		if pta_item is not None:
+			plugin_to_activate = pta_item.plugin_object
+			if plugin_to_activate is not None:
+				log.debug("Activating plugin: %s.%s"% (category,name))
+				plugin_to_activate.activate()
+				return plugin_to_activate			
+		return None
+
+
+	def deactivatePluginByName(self,name,category="Default"):
+		"""
+		Desactivate a plugin corresponding to a given category + name.
+		"""
+		if category in self.category_mapping:
+			plugin_to_deactivate = None
+			for item in self.category_mapping[category]:
+				if item.name == name:
+					plugin_to_deactivate = item.plugin_object
+					break
+			if plugin_to_deactivate is not None:
+				log.debug("Deactivating plugin: %s.%s"% (category,name))
+				plugin_to_deactivate.deactivate()
+				return plugin_to_deactivate			
+		return None
+
+
+class PluginManagerSingleton(object):
+	"""
+	Singleton version of the most basic plugin manager.
+
+	Being a singleton, this class should not be initialised explicitly
+	and the ``get`` classmethod must be called instead.
+
+	To call one of this class's methods you have to use the ``get``
+	method in the following way:
+	``PluginManagerSingleton.get().themethodname(theargs)``
+
+	To set up the various coonfigurables variables of the
+	PluginManager's behaviour please call explicitly the following
+	methods:
+
+	  - ``setCategoriesFilter`` for ``categories_filter``
+	  - ``setPluginPlaces`` for ``directories_list``
+	  - ``setPluginInfoExtension`` for ``plugin_info_ext``
+	"""
+	
+	__instance = None
+	
+	__decoration_chain = None
+
+	def __init__(self):
+		if self.__instance is not None:
+			raise Exception("Singleton can't be created twice !")
+				
+	def setBehaviour(self,list_of_pmd):
+		"""
+		Set the functionalities handled by the plugin manager by
+		giving a list of ``PluginManager`` decorators.
+		
+		This function shouldn't be called several time in a same
+		process, but if it is only the first call will have an effect.
+
+		It also has an effect only if called before the initialisation
+		of the singleton.
+
+		In cases where the function is indeed going to change anything
+		the ``True`` value is return, in all other cases, the ``False``
+		value is returned.
+		"""
+		if self.__decoration_chain is None and self.__instance is None:
+			log.debug("Setting up a specific behaviour for the PluginManagerSingleton")
+			self.__decoration_chain = list_of_pmd
+			return True
+		else:
+			log.debug("Useless call to setBehaviour: the singleton is already instanciated of already has a behaviour.")
+			return False
+	setBehaviour = classmethod(setBehaviour)
+
+
+	def get(self):
+		"""
+		Actually create an instance
+		"""
+		if self.__instance is None:
+			if self.__decoration_chain is not None:
+				# Get the object to be decorated
+#				print self.__decoration_chain
+				pm = self.__decoration_chain[0]()
+				for cls_item in self.__decoration_chain[1:]:
+#					print cls_item
+					pm = cls_item(decorated_manager=pm)
+				# Decorate the whole object
+				self.__instance = pm
+			else:
+				# initialise the 'inner' PluginManagerDecorator
+				self.__instance = PluginManager()			
+			log.debug("PluginManagerSingleton initialised")
+		return self.__instance
+	get = classmethod(get)
+
+
+# For backward compatility import the most basic decorator (it changed
+# place as of v1.8)
+from yapsy.PluginManagerDecorator import PluginManagerDecorator

--- a/src/yapsy/PluginManagerDecorator.py
+++ b/src/yapsy/PluginManagerDecorator.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+Provide an easy way to build a chain of decorators extending the
+functionalities of the default plugin manager, when it comes to
+activating, deactivating or looking into loaded plugins.
+
+The ``PluginManagerDecorator`` is the base class to be inherited by
+each element of the chain of decorator.
+
+.. warning:: If you want to customise the way the plugins are detected
+             and loaded, you should not try to do it by implementing a
+             new ``PluginManagerDecorator``. Instead, you'll have to
+             reimplement the :doc:`PluginManager` itself. And if you
+             do so by enforcing the ``PluginManager`` interface, just
+             giving an instance of your new manager class to the
+             ``PluginManagerDecorator`` should be transparent to the
+             "stantard" decorators.
+
+API
+===
+"""
+
+import os
+
+from yapsy.IPlugin import IPlugin
+from yapsy import log
+
+
+class PluginManagerDecorator(object):
+	"""
+	Add several responsibilities to a plugin manager object in a
+	more flexible way than by mere subclassing. This is indeed an
+	implementation of the Decorator Design Patterns.
+        
+	
+	There is also an additional mechanism that allows for the
+	automatic creation of the object to be decorated when this object
+	is an instance of PluginManager (and not an instance of its
+	subclasses). This way we can keep the plugin managers creation
+	simple when the user don't want to mix a lot of 'enhancements' on
+	the base class.
+
+	
+	About the __init__:
+
+	Mimics the PluginManager's __init__ method and wraps an
+	instance of this class into this decorator class.
+		
+	  - *If the decorated_object is not specified*, then we use the
+	    PluginManager class to create the 'base' manager, and to do
+	    so we will use the arguments: ``categories_filter``,
+	    ``directories_list``, and ``plugin_info_ext`` or their
+	    default value if they are not given.
+	  - *If the decorated object is given*, these last arguments are
+	    simply **ignored** !
+
+	All classes (and especially subclasses of this one) that want
+	to be a decorator must accept the decorated manager as an
+	object passed to the init function under the exact keyword
+	``decorated_object``.
+	"""
+        
+	def __init__(self, decorated_object=None,
+				 # The following args will only be used if we need to
+				 # create a default PluginManager
+				 categories_filter=None, 
+				 directories_list=None, 
+				 plugin_info_ext="yapsy-plugin"):
+		if directories_list is None:
+			directories_list = [os.path.dirname(__file__)]
+		if categories_filter is None:
+			categories_filter = {"Default": IPlugin}
+		if decorated_object is None:
+			log.debug("Creating a default PluginManager instance to be decorated.")
+			from yapsy.PluginManager import PluginManager
+			decorated_object = PluginManager(categories_filter, 
+											 directories_list,
+											 plugin_info_ext)
+		self._component = decorated_object
+
+	def __getattr__(self,name):
+		"""
+		Decorator trick copied from:
+		http://www.pasteur.fr/formation/infobio/python/ch18s06.html
+		"""
+# 		print "looking for %s in %s" % (name, self.__class__)
+		return getattr(self._component,name)
+		
+	
+	def collectPlugins(self):
+		"""
+		This function will usually be a shortcut to successively call
+		``self.locatePlugins`` and then ``self.loadPlugins`` which are
+		very likely to be redefined in each new decorator.
+
+		So in order for this to keep on being a "shortcut" and not a
+		real pain, I'm redefining it here.
+		"""
+		self.locatePlugins()
+		self.loadPlugins()

--- a/src/yapsy/VersionedPluginManager.py
+++ b/src/yapsy/VersionedPluginManager.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+Defines the basic interface for a plugin manager that also keeps track
+of versions of plugins
+
+API
+===
+"""
+
+
+from packaging.version import Version
+
+from yapsy.PluginInfo import PluginInfo
+from yapsy.IPlugin import IPlugin
+from yapsy.PluginManagerDecorator import PluginManagerDecorator
+
+
+class VersionedPluginInfo(PluginInfo):
+	"""
+	Gather some info about a plugin such as its name, author,
+	description...
+	"""
+	
+	def __init__(self, plugin_name, plugin_path):
+		PluginInfo.__init__(self, plugin_name, plugin_path)
+		# version number is now required to be a Version object
+		self.version	= Version("0.0")
+
+	def setVersion(self, vstring):
+		self.version = Version(vstring)
+
+
+class VersionedPluginManager(PluginManagerDecorator):
+	"""
+	Handle plugin versioning by making sure that when several
+	versions are present for a same plugin, only the latest version is
+	manipulated via the standard methods (eg for activation and
+	deactivation)
+	
+	More precisely, for operations that must be applied on a single
+	named plugin at a time (``getPluginByName``,
+	``activatePluginByName``, ``deactivatePluginByName`` etc) the
+	targetted plugin will always be the one with the latest version.
+	
+	.. note:: The older versions of a given plugin are still reachable
+	          via the ``getPluginsOfCategoryFromAttic`` method.
+	"""
+	
+	def __init__(self, 
+				 decorated_manager=None,
+				 categories_filter={"Default":IPlugin}, 
+				 directories_list=None, 
+				 plugin_info_ext="yapsy-plugin"):
+		# Create the base decorator class
+		PluginManagerDecorator.__init__(self,decorated_manager,
+										categories_filter,
+										directories_list,
+										plugin_info_ext)
+		self.setPluginInfoClass(VersionedPluginInfo)
+		# prepare the storage for the early version of the plugins,
+		# for which only the latest version is the one that will be
+		# kept in the "core" plugin storage.
+		self._prepareAttic()
+		
+	def _prepareAttic(self):
+		"""
+		Create and correctly initialize the storage where the wrong
+		version of the plugins will be stored.
+		"""
+		self._attic = {}
+		for categ in self.getCategories():
+			self._attic[categ] = []
+	
+	def setCategoriesFilter(self, categories_filter):
+		"""
+		Set the categories of plugins to be looked for as well as the
+		way to recognise them.
+
+		Note: will also reset the attic toa void inconsistencies.
+		"""
+		self._component.setCategoriesFilter(categories_filter)
+		self._prepareAttic()
+	
+	def getLatestPluginsOfCategory(self,category_name):
+		"""
+		DEPRECATED(>1.8): Please consider using getPluginsOfCategory
+		instead.
+		
+		Return the list of all plugins belonging to a category.
+		"""
+		return self.getPluginsOfCategory(category_name)
+	
+	def loadPlugins(self, callback=None, callback_after=None):
+		"""
+		Load the candidate plugins that have been identified through a
+		previous call to locatePlugins.
+
+		In addition to the baseclass functionality, this subclass also
+		needs to find the latest version of each plugin.
+		"""
+		self._prepareAttic()
+		self._component.loadPlugins(callback, callback_after)
+		for categ in self.getCategories():
+			latest_plugins = {}
+			allPlugins = self.getPluginsOfCategory(categ)
+			# identify the latest version of each plugin
+			for plugin in allPlugins:
+				name = plugin.name
+				version = plugin.version
+				if name in latest_plugins:
+					if version > latest_plugins[name].version:
+						older_plugin = latest_plugins[name]
+						latest_plugins[name] = plugin
+						self.removePluginFromCategory(older_plugin,categ)
+						self._attic[categ].append(older_plugin)
+					else:
+						self.removePluginFromCategory(plugin,categ)
+						self._attic[categ].append(plugin)
+				else:
+					latest_plugins[name] = plugin
+
+	def getPluginsOfCategoryFromAttic(self,categ):
+		"""
+		Access the older version of plugins for which only the latest
+		version is available through standard methods.
+		"""
+		return self._attic[categ]
+			

--- a/src/yapsy/__init__.py
+++ b/src/yapsy/__init__.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+
+Overview
+========
+
+Yapsy's main purpose is to offer a way to easily design a plugin
+system in Python, and motivated by the fact that many other Python
+plugin system are either too complicated for a basic use or depend on
+a lot of libraries. Yapsy only depends on Python's standard library.
+
+|yapsy| basically defines two core classes:
+
+- a fully functional though very simple ``PluginManager`` class
+
+- an interface ``IPlugin`` which defines the interface of plugin
+  instances handled by the ``PluginManager``
+
+
+Getting started
+===============
+
+The basic classes defined by |yapsy| should work "as is" and enable
+you to load and activate your plugins. So that the following code
+should get you a fully working plugin management system::
+
+   from yapsy.PluginManager import PluginManager
+   
+   # Build the manager
+   simplePluginManager = PluginManager()
+   # Tell it the default place(s) where to find plugins
+   simplePluginManager.setPluginPlaces(["path/to/myplugins"])
+   # Load all plugins
+   simplePluginManager.collectPlugins()
+
+   # Activate all loaded plugins
+   for pluginInfo in simplePluginManager.getAllPlugins():
+      simplePluginManager.activatePluginByName(pluginInfo.name)
+
+
+.. note:: The ``plugin_info`` object (typically an instance of
+          ``IPlugin``) plays as *the entry point of each
+          plugin*. That's also where |yapsy| ceases to guide you: it's
+          up to you to define what your plugins can do and how you
+          want to talk to them ! Talking to your plugin will then look
+          very much like the following::
+
+             # Trigger 'some action' from the loaded plugins
+             for pluginInfo in simplePluginManager.getAllPlugins():
+                pluginInfo.plugin_object.doSomething(...)
+
+"""
+
+__version__="2.0.0"
+
+# tell epydoc that the documentation is in the reStructuredText format
+__docformat__ = "restructuredtext en"
+
+# provide a default named log for package-wide use
+import logging
+log = logging.getLogger('yapsy')
+
+# Some constants concerning the plugins
+PLUGIN_NAME_FORBIDEN_STRING=";;"
+"""
+.. warning:: This string (';;' by default) is forbidden in plugin
+             names, and will be usable to describe lists of plugins
+             for instance (see :doc:`ConfigurablePluginManager`)
+"""
+
+import re
+RE_NON_ALPHANUM = re.compile(r"\W")
+
+
+def NormalizePluginNameForModuleName(pluginName):
+	"""
+	Normalize a plugin name into a safer name for a module name.
+	
+	.. note:: may do a little more modifications than strictly
+	          necessary and is not optimized for speed.
+	"""
+	if len(pluginName)==0:
+		return "_"
+	if pluginName[0].isdigit():
+		pluginName = "_" + pluginName
+	ret = RE_NON_ALPHANUM.sub("_",pluginName)
+	return ret

--- a/src/yapsy/compat.py
+++ b/src/yapsy/compat.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+"""
+Adapted from pythoncompat https://github.com/kennethreitz/requests/blob/724a3889bcd26c318cd4063519e67581d3be5d7e/requests/compat.py
+
+License  (ISC):
+
+Copyright (c) 2012 Kenneth Reitz.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+"""
+
+
+import sys
+
+# -------
+# Pythons
+# -------
+
+# Syntax sugar.
+_ver = sys.version_info
+
+#: Python 2.x?
+is_py2 = (_ver[0] == 2)
+
+#: Python 3.x?
+is_py3 = (_ver[0] == 3)
+
+
+if is_py2:
+    from StringIO import StringIO
+    from ConfigParser import ConfigParser
+
+    builtin_str = str
+    bytes = str
+    str = unicode
+    basestring = basestring
+    numeric_types = (int, long, float)
+
+
+elif is_py3:
+    from io import StringIO
+    from configparser import ConfigParser
+
+    builtin_str = str
+    str = str
+    bytes = bytes
+    basestring = (str, bytes)
+    numeric_types = (int, float)


### PR DESCRIPTION
<!--
Thank you for your interest in improving Obfuscapk.

Please describe the bug fix(es) and/or new feature(s) you are proposing.

NOTE:
    * if you're including code snippets/logs, please format them properly (see https://help.github.com/github/writing-on-github/basic-writing-and-formatting-syntax#quoting-code);
    * blocks starting with `< !--` and ending with `-- >` (without spaces) are treated as comments and won't be rendered, so please don't edit the text inside these blocks since your modifications won't be visible. If you want the text to be visible, remove `< !--` and `-- >` tags.
-->



### Description

This PR fixes several packaging issues that were preventing Obfuscapk from running correctly as a standalone tool.

### Proposed solution

- A local copy of the `Yapsy` package has been included to remove the dependency on a remote Git version.
- Paths and imports have been adjusted to properly support plugin loading without runtime errors.
- `requirements.txt` has been updated to reflect the removal of the external Yapsy dependency.

### Type of change

<!-- Please put an x between the brackets of each line that applies below, so that [ ] becomes [x] (without leaving spaces around the x) -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Other (e.g., refactoring, documentation etc.)



### Additional context

<!-- Is there anything else you can add about the PR? E.g., why you chose the solution you did, what alternatives you considered etc. (insert text below this line) -->



### Checklist

<!-- Please put an x between the brackets of each line that applies below, so that [ ] becomes [x] (without leaving spaces around the x) -->

* [x] I have read the [contributing](https://github.com/ClaudiuGeorgiu/Obfuscapk/blob/master/docs/CONTRIBUTING.md) guidelines
* [x] I have performed a self-review of my own code (added comments, corrected misspellings etc.)
* [x] My code follows the style guidelines of this project
* [x] I have made corresponding changes to the documentation (if appropriate)
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing tests pass locally with my changes
